### PR TITLE
Port to Minecraft 26.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version "${loom_version}"
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
     id 'maven-publish'
 }
 
@@ -41,17 +41,16 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     //Modmenu
-    modImplementation "maven.modrinth:modmenu:${project.modmenu_version}"
+    implementation "maven.modrinth:modmenu:${project.modmenu_version}"
 
     //Yacl
-    modImplementation "dev.isxander:yet-another-config-lib:${project.yacl_version}"
+    implementation "dev.isxander:yet-another-config-lib:${project.yacl_version}"
 }
 
 processResources {
@@ -63,7 +62,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    it.options.release = 21
+    it.options.release = 25
 }
 
 java {
@@ -72,8 +71,8 @@ java {
     // If you remove this line, sources will not be generated.
     withSourcesJar()
 
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
@@ -100,6 +99,6 @@ publishing {
     }
 }
 
-tasks.named("remapJar") {
+tasks.named("jar") {
     archiveFileName = project.archives_base_name + "-" + project.mod_version + "+mc" + project.mc_compatibility_version + ".jar"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,22 +10,21 @@ org.gradle.configureondemand=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.10
-yarn_mappings=1.21.10+build.3
-loader_version=0.18.1
-loom_version=1.13-SNAPSHOT
+minecraft_version=26.1.2
+loader_version=0.19.3
+loom_version=1.17.11
 
 # Fabric API
-fabric_version=0.138.3+1.21.10
+fabric_version=0.152.1+26.1.2
 
 #Mod Menu
-modmenu_version=16.0.0-rc.1
+modmenu_version=18.0.0-beta.1
 
 #YACL
-yacl_version=3.8.0+1.21.9-fabric
+yacl_version=3.9.4+26.1-fabric
 
 # Mod Properties
 mod_version=4.3.0
 maven_group=net.sn0wix_
 archives_base_name=NotEnoughKeybinds
-mc_compatibility_version=1.21.9-1.21.10
+mc_compatibility_version=26.1-26.1.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/NotEnoughKeybinds.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/NotEnoughKeybinds.java
@@ -4,7 +4,7 @@ import net.fabricmc.api.ClientModInitializer;
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 import net.sn0wix_.notEnoughKeybinds.config.*;
 import net.sn0wix_.notEnoughKeybinds.events.ClientEndTickEvent;
 import net.sn0wix_.notEnoughKeybinds.keybinds.ChatKeys;
@@ -18,7 +18,7 @@ public class NotEnoughKeybinds implements ClientModInitializer {
     public static final String MOD_ID = "not-enough-keybinds";
     public static final String MOD_NAME = "NotEnoughKeybinds";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
-    public static final Identifier ICON = Identifier.of(MOD_ID, "icon.png");
+    public static final Identifier ICON = Identifier.fromNamespaceAndPath(MOD_ID, "icon.png");
 
     public static final DebugKeysConfig DEBUG_KEYS_CONFIG = DebugKeysConfig.getConfig();
     public static final ChatKeysConfig CHAT_KEYS_CONFIG = ChatKeysConfig.getConfig();
@@ -38,6 +38,6 @@ public class NotEnoughKeybinds implements ClientModInitializer {
     }
 
     public static Identifier getIdentifier(String path) {
-        return Identifier.of(MOD_ID, path);
+        return Identifier.fromNamespaceAndPath(MOD_ID, path);
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/config/ChatKeysConfig.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/config/ChatKeysConfig.java
@@ -1,13 +1,13 @@
 package net.sn0wix_.notEnoughKeybinds.config;
 
 import com.google.gson.GsonBuilder;
+import com.mojang.blaze3d.platform.InputConstants;
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.resources.Identifier;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.ChatKeyBinding;
 import org.lwjgl.glfw.GLFW;
@@ -17,7 +17,7 @@ import java.util.HashMap;
 
 public class ChatKeysConfig {
     public static ConfigClassHandler<ChatKeysConfig> HANDLER = ConfigClassHandler.createBuilder(ChatKeysConfig.class)
-            .id(Identifier.of(NotEnoughKeybinds.MOD_ID, "chat_keys"))
+            .id(Identifier.fromNamespaceAndPath(NotEnoughKeybinds.MOD_ID, "chat_keys"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
                     .setPath(FabricLoader.getInstance().getConfigDir().resolve(NotEnoughKeybinds.MOD_ID).resolve("chat_keys.json"))
                     .appendGsonBuilder(GsonBuilder::setPrettyPrinting)
@@ -31,25 +31,25 @@ public class ChatKeysConfig {
 
 
     public void addKey(ChatKeyBinding binding) {
-        chatKeys.put(binding.getId(), new ChatKeyValues(binding.getChatMessage(), binding.getSettingsDisplayName().getString(), binding.getDefaultKey()));
+        chatKeys.put(binding.getName(), new ChatKeyValues(binding.getChatMessage(), binding.getSettingsDisplayName().getString(), binding.getDefaultKey()));
         saveConfig();
     }
 
     public void removeKey(ChatKeyBinding binding) {
-        chatKeys.remove(binding.getId());
+        chatKeys.remove(binding.getName());
         saveConfig();
     }
 
     public void addKeyIf(ChatKeyBinding binding) {
-        chatKeys.remove(binding.getId());
-        chatKeys.put(binding.getId(), new ChatKeyValues(binding.getChatMessage(), binding.getSettingsDisplayName().getString(), InputUtil.fromTranslationKey(binding.getBoundKeyTranslation())));
+        chatKeys.remove(binding.getName());
+        chatKeys.put(binding.getName(), new ChatKeyValues(binding.getChatMessage(), binding.getSettingsDisplayName().getString(), InputConstants.getKey(binding.getBoundKeyTranslation())));
         saveConfig();
     }
 
-    public void updateKey(String translationKey, InputUtil.Key key) {
+    public void updateKey(String translationKey, InputConstants.Key key) {
         chatKeys.forEach((s, chatKeyValues) -> {
             if (s.equals(translationKey)) {
-                chatKeyValues.setKey(key.getCode());
+                chatKeyValues.setKey(key.getValue());
             }
         });
         saveConfig();
@@ -77,14 +77,14 @@ public class ChatKeysConfig {
         private String name;
         private int keyCode;
 
-        public ChatKeyValues(String message, String name, InputUtil.Key key) {
+        public ChatKeyValues(String message, String name, InputConstants.Key key) {
             this.message = message;
             this.name = name;
-            this.keyCode = key.getCode();
+            this.keyCode = key.getValue();
         }
 
-        public InputUtil.Key getKey() {
-            return keyCode == -1 ? InputUtil.UNKNOWN_KEY : InputUtil.fromKeyCode(new KeyInput(keyCode, GLFW.glfwGetKeyScancode(keyCode), 0));
+        public InputConstants.Key getKey() {
+            return keyCode == -1 ? InputConstants.UNKNOWN : InputConstants.getKey(new KeyEvent(keyCode, GLFW.glfwGetKeyScancode(keyCode), 0));
         }
 
         public String getMessage() {

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/config/DebugKeysConfig.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/config/DebugKeysConfig.java
@@ -1,12 +1,12 @@
 package net.sn0wix_.notEnoughKeybinds.config;
 
 import com.google.gson.GsonBuilder;
+import com.mojang.blaze3d.platform.InputConstants;
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.F3DebugKeys;
 
@@ -14,7 +14,7 @@ import java.util.HashMap;
 
 public class DebugKeysConfig {
     public static ConfigClassHandler<DebugKeysConfig> HANDLER = ConfigClassHandler.createBuilder(DebugKeysConfig.class)
-            .id(Identifier.of(NotEnoughKeybinds.MOD_ID, "debug_keys"))
+            .id(Identifier.fromNamespaceAndPath(NotEnoughKeybinds.MOD_ID, "debug_keys"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
                     .setPath(FabricLoader.getInstance().getConfigDir().resolve(NotEnoughKeybinds.MOD_ID).resolve("debug_keys.json"))
                     .appendGsonBuilder(GsonBuilder::setPrettyPrinting)
@@ -46,7 +46,7 @@ public class DebugKeysConfig {
         saveConfig();
     }
 
-    public InputUtil.Key getKey(String keybinding) {
-        return InputUtil.fromTranslationKey(debugKeybindings.get(keybinding));
+    public InputConstants.Key getKey(String keybinding) {
+        return InputConstants.getKey(debugKeybindings.get(keybinding));
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/config/EquipElytraConfig.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/config/EquipElytraConfig.java
@@ -5,15 +5,15 @@ import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.item.Items;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.Items;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 
 public class EquipElytraConfig {
     public static ConfigClassHandler<EquipElytraConfig> HANDLER = ConfigClassHandler.createBuilder(EquipElytraConfig.class)
-            .id(Identifier.of(NotEnoughKeybinds.MOD_ID, "equip_elytra"))
+            .id(Identifier.fromNamespaceAndPath(NotEnoughKeybinds.MOD_ID, "equip_elytra"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
                     .setPath(FabricLoader.getInstance().getConfigDir().resolve(NotEnoughKeybinds.MOD_ID).resolve("equip_elytra.json"))
                     .appendGsonBuilder(GsonBuilder::setPrettyPrinting)
@@ -73,11 +73,11 @@ public class EquipElytraConfig {
     }
 
     public void cycleSlot() {
-        if (PlayerInventory.isValidHotbarIndex(fireworkSwapSlot)) {
+        if (Inventory.isHotbarSlot(fireworkSwapSlot)) {
             fireworkSwapSlot++;
         }
 
-        if (!PlayerInventory.isValidHotbarIndex(fireworkSwapSlot)) {
+        if (!Inventory.isHotbarSlot(fireworkSwapSlot)) {
             fireworkSwapSlot = 0;
         }
     }
@@ -113,7 +113,7 @@ public class EquipElytraConfig {
 
         if (!value.equals("off")) {
             if (value.equals("elytra")) {
-                swapValue = Items.ELYTRA.getTranslationKey();
+                swapValue = Items.ELYTRA.getDescriptionId();
             } else if (value.equals("chestplate")) {
                 swapValue = TextUtils.getTranslationKey("chestplate");
             }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/config/NotEKSettings.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/config/NotEKSettings.java
@@ -5,12 +5,12 @@ import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 
 public class NotEKSettings {
     public static ConfigClassHandler<NotEKSettings> HANDLER = ConfigClassHandler.createBuilder(NotEKSettings.class)
-            .id(Identifier.of(NotEnoughKeybinds.MOD_ID, "settings"))
+            .id(Identifier.fromNamespaceAndPath(NotEnoughKeybinds.MOD_ID, "settings"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
                     .setPath(FabricLoader.getInstance().getConfigDir().resolve(NotEnoughKeybinds.MOD_ID).resolve("settings.json"))
                     .appendGsonBuilder(GsonBuilder::setPrettyPrinting)

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/config/SwapTotemShieldConfig.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/config/SwapTotemShieldConfig.java
@@ -5,14 +5,14 @@ import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.item.Items;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.Items;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 
 public class SwapTotemShieldConfig {
     public static ConfigClassHandler<SwapTotemShieldConfig> HANDLER = ConfigClassHandler.createBuilder(SwapTotemShieldConfig.class)
-            .id(Identifier.of(NotEnoughKeybinds.MOD_ID, "swap_totem_shield"))
+            .id(Identifier.fromNamespaceAndPath(NotEnoughKeybinds.MOD_ID, "swap_totem_shield"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
                     .setPath(FabricLoader.getInstance().getConfigDir().resolve(NotEnoughKeybinds.MOD_ID).resolve("swap_totem_shield.json"))
                     .appendGsonBuilder(GsonBuilder::setPrettyPrinting)
@@ -71,9 +71,9 @@ public class SwapTotemShieldConfig {
 
         if (!value.equals("off")) {
             if (value.equals("shield")) {
-                swapValue = Items.SHIELD.getTranslationKey();
+                swapValue = Items.SHIELD.getDescriptionId();
             } else if (value.equals("totem")) {
-                swapValue = Items.TOTEM_OF_UNDYING.getTranslationKey();
+                swapValue = Items.TOTEM_OF_UNDYING.getDescriptionId();
             }
         }
 

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/events/ClientEndTickEvent.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/events/ClientEndTickEvent.java
@@ -1,14 +1,14 @@
 package net.sn0wix_.notEnoughKeybinds.events;
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.Minecraft;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.NotEKKeyBindings;
 
 public class ClientEndTickEvent implements ClientTickEvents.EndTick {
 
     @Override
-    public void onEndTick(MinecraftClient client) {
+    public void onEndTick(Minecraft client) {
         try {
             NotEKKeyBindings.getModKeybindsAsList().forEach(modKeyBinding -> modKeyBinding.tick(client));
         } catch (Exception e) {

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/AdvancedConfirmScreen.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/AdvancedConfirmScreen.java
@@ -1,31 +1,31 @@
 package net.sn0wix_.notEnoughKeybinds.gui;
 
 import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
-import net.minecraft.client.gui.screen.ConfirmScreen;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.screens.ConfirmScreen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 public class AdvancedConfirmScreen extends ConfirmScreen {
-    public AdvancedConfirmScreen(BooleanConsumer callback, Text title, Text message) {
+    public AdvancedConfirmScreen(BooleanConsumer callback, Component title, Component message) {
         super(callback, title, message);
     }
 
-    public AdvancedConfirmScreen(BooleanConsumer callback, Text title, Text message, Text yesText, Text noText) {
+    public AdvancedConfirmScreen(BooleanConsumer callback, Component title, Component message, Component yesText, Component noText) {
         super(callback, title, message, yesText, noText);
     }
 
     @Override
-    public boolean keyPressed(KeyInput input) {
-        if (getFocused() == null && input.getKeycode() == GLFW.GLFW_KEY_ENTER) {
+    public boolean keyPressed(KeyEvent input) {
+        if (getFocused() == null && input.input() == GLFW.GLFW_KEY_ENTER) {
             this.callback.accept(true);
             return true;
         }
 
-        if (input.getKeycode() == GLFW.GLFW_KEY_BACKSPACE) {
+        if (input.input() == GLFW.GLFW_KEY_BACKSPACE) {
             this.callback.accept(false);
             return true;
-        } else if (input.getKeycode() == GLFW.GLFW_KEY_DELETE) {
+        } else if (input.input() == GLFW.GLFW_KEY_DELETE) {
             this.callback.accept(true);
             return true;
         }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/IntFieldWidget.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/IntFieldWidget.java
@@ -1,29 +1,29 @@
 package net.sn0wix_.notEnoughKeybinds.gui;
 
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.client.input.CharInput;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.input.CharacterEvent;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 
-public class IntFieldWidget extends TextFieldWidget {
+public class IntFieldWidget extends EditBox {
     //TODO fix ctrl + v text bug
-    public IntFieldWidget(TextRenderer textRenderer, int width, int height, Text text) {
+    public IntFieldWidget(Font textRenderer, int width, int height, Component text) {
         super(textRenderer, width, height, text);
     }
 
-    public IntFieldWidget(TextRenderer textRenderer, int x, int y, int width, int height, Text text) {
+    public IntFieldWidget(Font textRenderer, int x, int y, int width, int height, Component text) {
         super(textRenderer, x, y, width, height, text);
     }
 
-    public IntFieldWidget(TextRenderer textRenderer, int x, int y, int width, int height, @Nullable TextFieldWidget copyFrom, Text text) {
+    public IntFieldWidget(Font textRenderer, int x, int y, int width, int height, @Nullable EditBox copyFrom, Component text) {
         super(textRenderer, x, y, width, height, copyFrom, text);
     }
 
     @Override
-    public boolean charTyped(CharInput input) {
+    public boolean charTyped(CharacterEvent input) {
         try {
-            Integer.parseInt(input.asString());
+            Integer.parseInt(input.codepointAsString());
         } catch (NumberFormatException e) {
             return false;
         }
@@ -32,8 +32,8 @@ public class IntFieldWidget extends TextFieldWidget {
     }
 
     @Override
-    public void setText(String text) {
-        super.setText(parseString(text));
+    public void setValue(String text) {
+        super.setValue(parseString(text));
     }
 
     public String parseString(String s) {

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/ParentScreenBlConsumer.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/ParentScreenBlConsumer.java
@@ -1,22 +1,21 @@
 package net.sn0wix_.notEnoughKeybinds.gui;
 
 import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-
 import java.util.function.Consumer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 
-public record ParentScreenBlConsumer(Screen parent, Consumer<MinecraftClient> consumer, boolean setParentIf) implements BooleanConsumer {
+public record ParentScreenBlConsumer(Screen parent, Consumer<Minecraft> consumer, boolean setParentIf) implements BooleanConsumer {
     @Override
     public void accept(boolean t) {
         if (t) {
-            consumer.accept(MinecraftClient.getInstance());
+            consumer.accept(Minecraft.getInstance());
 
             if (setParentIf) {
-                MinecraftClient.getInstance().setScreen(parent);
+                Minecraft.getInstance().setScreen(parent);
             }
         } else {
-            MinecraftClient.getInstance().setScreen(parent);
+            Minecraft.getInstance().setScreen(parent);
         }
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/SettingsScreen.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/SettingsScreen.java
@@ -2,10 +2,11 @@ package net.sn0wix_.notEnoughKeybinds.gui;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.*;
-import net.minecraft.screen.ScreenTexts;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.components.*;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.BasicLayoutWidget;
 
 @Environment(EnvType.CLIENT)
@@ -13,12 +14,12 @@ public abstract class SettingsScreen extends Screen {
     protected final Screen parent;
     public BasicLayoutWidget threePartsLayout = new BasicLayoutWidget(this);
 
-    public SettingsScreen(Screen parent, Text title) {
+    public SettingsScreen(Screen parent, Component title) {
         super(title);
         this.parent = parent;
     }
 
-    public SettingsScreen(Screen parent, Text title, int headerHeight, int footerHeight) {
+    public SettingsScreen(Screen parent, Component title, int headerHeight, int footerHeight) {
         this(parent, title);
         this.threePartsLayout.setHeaderHeight(headerHeight);
         this.threePartsLayout.setFooterHeight(footerHeight);
@@ -36,39 +37,39 @@ public abstract class SettingsScreen extends Screen {
         this.initHeader();
         this.initBody();
         this.initFooter();
-        this.threePartsLayout.forEachChild(this::addDrawableChild);
+        this.threePartsLayout.visitWidgets(this::addRenderableWidget);
 
-        this.refreshWidgetPositions();
+        this.repositionElements();
     }
 
     protected void initBody() {}
 
     public void initFooter() {
-        this.threePartsLayout.addFooter(ButtonWidget.builder(ScreenTexts.DONE, button -> this.close()).width(200).build());
+        this.threePartsLayout.addToFooter(Button.builder(CommonComponents.GUI_DONE, button -> this.onClose()).width(200).build());
     }
 
     public void initHeader() {
-        this.threePartsLayout.addHeader(this.title, this.textRenderer);
+        this.threePartsLayout.addTitleHeader(this.title, this.font);
     }
 
 
     @Override
-    public void refreshWidgetPositions() {
-        this.threePartsLayout.refreshPositions();
+    public void repositionElements() {
+        this.threePartsLayout.arrangeElements();
     }
 
     @Override
     public void removed() {
-        assert this.client != null;
-        this.client.options.write();
+        assert this.minecraft != null;
+        this.minecraft.options.save();
     }
 
     @Override
-    public void close() {
+    public void onClose() {
         saveOptions();
 
-        assert this.client != null;
-        this.client.setScreen(this.parent);
+        assert this.minecraft != null;
+        this.minecraft.setScreen(this.parent);
     }
 
     public void saveOptions() {

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/TexturedButtonWidget.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/TexturedButtonWidget.java
@@ -2,21 +2,21 @@ package net.sn0wix_.notEnoughKeybinds.gui;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.gl.RenderPipelines;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 
 @Environment(EnvType.CLIENT)
-public class TexturedButtonWidget extends ButtonWidget {
+public class TexturedButtonWidget extends Button {
     public Identifier TEXTURE;
     public int spriteWidth;
     public int spriteHeight;
     public int textureWidth;
     public int textureHeight;
 
-    public TexturedButtonWidget(int x, int y, int width, int height, Text message, PressAction onPress, NarrationSupplier narrationSupplier, Identifier texture, int spriteWidth, int spriteHeight, int textureWidth, int textureHeight) {
+    public TexturedButtonWidget(int x, int y, int width, int height, Component message, OnPress onPress, CreateNarration narrationSupplier, Identifier texture, int spriteWidth, int spriteHeight, int textureWidth, int textureHeight) {
         super(x, y, width, height, message, onPress, narrationSupplier);
         TEXTURE = texture;
         this.spriteWidth = spriteWidth;
@@ -27,10 +27,9 @@ public class TexturedButtonWidget extends ButtonWidget {
 
 
     @Override
-    public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
-        super.renderWidget(context, mouseX, mouseY, delta);
+    public void extractContents(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
         if (TEXTURE != null) {
-            context.drawTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, this.getX() + (this.width - spriteWidth) / 2,
+            context.blit(RenderPipelines.GUI_TEXTURED, TEXTURE, this.getX() + (this.width - spriteWidth) / 2,
                     this.getY() + (this.height - spriteHeight) / 2, 0, 0,
                     spriteWidth, spriteHeight, textureWidth, textureHeight);
         }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/BasicLayoutWidget.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/BasicLayoutWidget.java
@@ -3,18 +3,23 @@ package net.sn0wix_.notEnoughKeybinds.gui.screen;
 import java.util.function.Consumer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.*;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.layouts.FrameLayout;
+import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
+import net.minecraft.client.gui.layouts.LayoutElement;
+import net.minecraft.client.gui.layouts.LayoutSettings;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.components.*;
+import net.minecraft.network.chat.Component;
 
 @Environment(EnvType.CLIENT)
-public class BasicLayoutWidget extends ThreePartsLayoutWidget {
+public class BasicLayoutWidget extends HeaderAndFooterLayout {
     public static final int DEFAULT_HEADER_FOOTER_HEIGHT = 33;
     private int BODY_MARGIN_TOP = 5;
-    private final SimplePositioningWidget header = new SimplePositioningWidget();
-    private final SimplePositioningWidget footer = new SimplePositioningWidget();
-    private final SimplePositioningWidget body = new SimplePositioningWidget();
+    private final FrameLayout header = new FrameLayout();
+    private final FrameLayout footer = new FrameLayout();
+    private final FrameLayout body = new FrameLayout();
     private final Screen screen;
     private int headerHeight;
     private int footerHeight;
@@ -25,7 +30,7 @@ public class BasicLayoutWidget extends ThreePartsLayoutWidget {
     }
 
     public BasicLayoutWidget(Screen screen) {
-        this(screen, DEFAULT_HEADER_FOOTER_HEIGHT);
+        this(screen, DEFAULT_HEADER_AND_FOOTER_HEIGHT);
     }
 
     public BasicLayoutWidget(Screen screen, int headerFooterHeight) {
@@ -37,8 +42,8 @@ public class BasicLayoutWidget extends ThreePartsLayoutWidget {
         this.screen = screen;
         this.headerHeight = headerHeight;
         this.footerHeight = footerHeight;
-        this.header.getMainPositioner().relative(0.5F, 0.5F);
-        this.footer.getMainPositioner().relative(0.5F, 0.5F);
+        this.header.defaultChildLayoutSetting().align(0.5F, 0.5F);
+        this.footer.defaultChildLayoutSetting().align(0.5F, 0.5F);
     }
 
     @Override
@@ -72,56 +77,56 @@ public class BasicLayoutWidget extends ThreePartsLayoutWidget {
     }
 
     @Override
-    public void forEachElement(Consumer<Widget> consumer) {
-        this.header.forEachElement(consumer);
-        this.body.forEachElement(consumer);
-        this.footer.forEachElement(consumer);
+    public void visitChildren(Consumer<LayoutElement> consumer) {
+        this.header.visitChildren(consumer);
+        this.body.visitChildren(consumer);
+        this.footer.visitChildren(consumer);
     }
 
     @Override
-    public void refreshPositions() {
+    public void arrangeElements() {
         int i = this.getHeaderHeight();
         int j = this.getFooterHeight();
         this.header.setMinWidth(this.screen.width);
         this.header.setMinHeight(i);
         this.header.setPosition(0, 0);
-        this.header.refreshPositions();
+        this.header.arrangeElements();
         this.footer.setMinWidth(this.screen.width);
         this.footer.setMinHeight(j);
-        this.footer.refreshPositions();
+        this.footer.arrangeElements();
         this.footer.setY(this.screen.height - j);
         this.body.setMinWidth(this.screen.width);
-        this.body.refreshPositions();
+        this.body.arrangeElements();
         int k = i + BODY_MARGIN_TOP;
         int l = this.screen.height - j - this.body.getHeight();
         this.body.setPosition(0, Math.min(k, l));
     }
 
-    public <T extends Widget> T addHeader(T widget) {
-        return this.header.add(widget);
+    public <T extends LayoutElement> T addToHeader(T widget) {
+        return this.header.addChild(widget);
     }
 
-    public <T extends Widget> T addHeader(T widget, Consumer<Positioner> callback) {
-        return this.header.add(widget, callback);
+    public <T extends LayoutElement> T addToHeader(T widget, Consumer<LayoutSettings> callback) {
+        return this.header.addChild(widget, callback);
     }
 
-    public void addHeader(Text text, TextRenderer textRenderer) {
-        this.header.add(new TextWidget(text, textRenderer));
+    public void addTitleHeader(Component text, Font textRenderer) {
+        this.header.addChild(new StringWidget(text, textRenderer));
     }
 
-    public <T extends Widget> T addFooter(T widget) {
-        return this.footer.add(widget);
+    public <T extends LayoutElement> T addToFooter(T widget) {
+        return this.footer.addChild(widget);
     }
 
-    public <T extends Widget> T addFooter(T widget, Consumer<Positioner> callback) {
-        return this.footer.add(widget, callback);
+    public <T extends LayoutElement> T addToFooter(T widget, Consumer<LayoutSettings> callback) {
+        return this.footer.addChild(widget, callback);
     }
 
-    public <T extends Widget> T addBody(T widget) {
-        return this.body.add(widget);
+    public <T extends LayoutElement> T addToContents(T widget) {
+        return this.body.addChild(widget);
     }
 
-    public <T extends Widget> T addBody(T widget, Consumer<Positioner> callback) {
-        return this.body.add(widget, callback);
+    public <T extends LayoutElement> T addToContents(T widget, Consumer<LayoutSettings> callback) {
+        return this.body.addChild(widget, callback);
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/INotEKLayoutTemplate.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/INotEKLayoutTemplate.java
@@ -1,19 +1,19 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen;
 
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.client.gui.widget.ThreePartsLayoutWidget;
+import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
+import net.minecraft.client.gui.layouts.LinearLayout;
 
 public interface INotEKLayoutTemplate {
-    default void initBodyWidget(DirectionalLayoutWidget left, DirectionalLayoutWidget right, ThreePartsLayoutWidget layoutWidget) {
-        DirectionalLayoutWidget body = DirectionalLayoutWidget.horizontal().spacing(5);
-        body.add(left);
-        body.add(right);
+    default void initBodyWidget(LinearLayout left, LinearLayout right, HeaderAndFooterLayout layoutWidget) {
+        LinearLayout body = LinearLayout.horizontal().spacing(5);
+        body.addChild(left);
+        body.addChild(right);
 
-        layoutWidget.addBody(body);
+        layoutWidget.addToContents(body);
     }
 
-    default DirectionalLayoutWidget getColumnWidget() {
-        return DirectionalLayoutWidget.vertical().spacing(2);
+    default LinearLayout getColumnWidget() {
+        return LinearLayout.vertical().spacing(2);
     }
 
     void initButtons();

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keySettings/ChatKeyScreen.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keySettings/ChatKeyScreen.java
@@ -1,14 +1,14 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen.keySettings;
 
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.client.gui.widget.TextWidget;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.screen.ScreenTexts;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.gui.ParentScreenBlConsumer;
 import net.sn0wix_.notEnoughKeybinds.gui.SettingsScreen;
 import net.sn0wix_.notEnoughKeybinds.keybinds.ChatKeys;
@@ -18,26 +18,26 @@ import net.sn0wix_.notEnoughKeybinds.util.Utils;
 import org.lwjgl.glfw.GLFW;
 
 public class ChatKeyScreen extends SettingsScreen {
-    public static final Text KEYBIND_NAME_TEXT = Text.translatable(TextUtils.getTranslationKey("keybind_name")).formatted(Formatting.GRAY);
-    public static final Text MESSAGE_TEXT_FORMATTED = Text.translatable(TextUtils.getTranslationKey("text")).formatted(Formatting.GRAY);
-    public static final Text MESSAGE_TEXT = Text.translatable(TextUtils.getTranslationKey("set_to_message"));
-    public static final Text COMMAND_TEXT = Text.translatable(TextUtils.getTranslationKey("set_to_command"));
+    public static final Component KEYBIND_NAME_TEXT = Component.translatable(TextUtils.getTranslationKey("keybind_name")).withStyle(ChatFormatting.GRAY);
+    public static final Component MESSAGE_TEXT_FORMATTED = Component.translatable(TextUtils.getTranslationKey("text")).withStyle(ChatFormatting.GRAY);
+    public static final Component MESSAGE_TEXT = Component.translatable(TextUtils.getTranslationKey("set_to_message"));
+    public static final Component COMMAND_TEXT = Component.translatable(TextUtils.getTranslationKey("set_to_command"));
 
 
     public final ChatKeyBinding binding;
-    public TextFieldWidget nameWidget;
-    public TextFieldWidget messageWidget;
-    public ButtonWidget commandMessageWidget;
-    public ButtonWidget doneButton;
-    public ButtonWidget deleteButton;
+    public EditBox nameWidget;
+    public EditBox messageWidget;
+    public Button commandMessageWidget;
+    public Button doneButton;
+    public Button deleteButton;
 
     public String name;
     public String message;
 
-    public DirectionalLayoutWidget body = DirectionalLayoutWidget.vertical().spacing(20);
+    public LinearLayout body = LinearLayout.vertical().spacing(20);
 
     public ChatKeyScreen(Screen parent, ChatKeyBinding binding) {
-        super(parent, Text.translatable(TextUtils.getSettingsTranslationKey("chat_keys")));
+        super(parent, Component.translatable(TextUtils.getSettingsTranslationKey("chat_keys")));
         this.binding = binding;
         this.name = binding.getSettingsDisplayName().getString();
         this.message = binding.getChatMessage();
@@ -46,57 +46,57 @@ public class ChatKeyScreen extends SettingsScreen {
     @Override
     protected void initBody() {
         initButtons();
-        threePartsLayout.addBody(body);
+        threePartsLayout.addToContents(body);
     }
 
     @Override
     public void initFooter() {
-        DirectionalLayoutWidget directionalLayoutWidget = this.threePartsLayout.addFooter(DirectionalLayoutWidget.horizontal().spacing(8));
-        directionalLayoutWidget.add(deleteButton);
-        directionalLayoutWidget.add(doneButton);
+        LinearLayout directionalLayoutWidget = this.threePartsLayout.addToFooter(LinearLayout.horizontal().spacing(8));
+        directionalLayoutWidget.addChild(deleteButton);
+        directionalLayoutWidget.addChild(doneButton);
     }
 
     public void initButtons() {
-        DirectionalLayoutWidget top = DirectionalLayoutWidget.vertical().spacing(2);
-        DirectionalLayoutWidget bottom = DirectionalLayoutWidget.vertical().spacing(2);
+        LinearLayout top = LinearLayout.vertical().spacing(2);
+        LinearLayout bottom = LinearLayout.vertical().spacing(2);
 
-        top.add(new TextWidget(200, 20, KEYBIND_NAME_TEXT, textRenderer));
-        bottom.add(new TextWidget(200, 20, MESSAGE_TEXT_FORMATTED, textRenderer));
+        top.addChild(new StringWidget(200, 20, KEYBIND_NAME_TEXT, font));
+        bottom.addChild(new StringWidget(200, 20, MESSAGE_TEXT_FORMATTED, font));
 
-        doneButton = ButtonWidget.builder(ScreenTexts.DONE, button -> {
-            binding.setChatMessage(messageWidget.getText());
-            binding.setSettingDisplayName(nameWidget.getText());
+        doneButton = Button.builder(CommonComponents.GUI_DONE, button -> {
+            binding.setChatMessage(messageWidget.getValue());
+            binding.setSettingDisplayName(nameWidget.getValue());
 
             if (!ChatKeys.CHAT_KEYS_MOD_CATEGORY.addKeyIf(binding)) {
                 Utils.showToastNotification(TextUtils.getText("chat_binding.create", binding.getSettingsDisplayName()));
             }
-            assert client != null;
-            client.setScreen(parent);
+            assert minecraft != null;
+            minecraft.setScreen(parent);
         }).build();
 
-        deleteButton = ButtonWidget.builder(TextUtils.getText("delete"), button -> {
-            assert client != null;
-            client.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(this, client1 -> {
+        deleteButton = Button.builder(TextUtils.getText("delete"), button -> {
+            assert minecraft != null;
+            minecraft.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(this, client1 -> {
                         ChatKeys.CHAT_KEYS_MOD_CATEGORY.removeKey(binding);
-                        client.setScreen(parent);
+                        minecraft.setScreen(parent);
                         Utils.showToastNotification(TextUtils.getText("chat_binding.delete", binding.getSettingsDisplayName()));
                     }, false),
-                    Text.translatable(TextUtils.getTranslationKey("delete_keybind.confirm"), nameWidget.getText())));
+                    Component.translatable(TextUtils.getTranslationKey("delete_keybind.confirm"), nameWidget.getValue())));
         }).build();
 
-        nameWidget = new TextFieldWidget(textRenderer, 150, 20, KEYBIND_NAME_TEXT);
-        nameWidget.setChangedListener(s -> updateChildren());
-        nameWidget.setText(name);
+        nameWidget = new EditBox(font, 150, 20, KEYBIND_NAME_TEXT);
+        nameWidget.setResponder(s -> updateChildren());
+        nameWidget.setValue(name);
 
 
-        commandMessageWidget = ButtonWidget.builder(
+        commandMessageWidget = Button.builder(
                 COMMAND_TEXT,
                 button -> {
-                    if (messageWidget.getText().startsWith("/")) {
-                        messageWidget.setText(messageWidget.getText().replaceFirst("/", ""));
+                    if (messageWidget.getValue().startsWith("/")) {
+                        messageWidget.setValue(messageWidget.getValue().replaceFirst("/", ""));
                         button.setMessage(COMMAND_TEXT);
                     } else {
-                        messageWidget.setText("/" + messageWidget.getText());
+                        messageWidget.setValue("/" + messageWidget.getValue());
                         button.setMessage(MESSAGE_TEXT);
                     }
 
@@ -105,9 +105,9 @@ public class ChatKeyScreen extends SettingsScreen {
                 }).size(150, 20).build();
 
 
-        messageWidget = new TextFieldWidget(textRenderer, 310, 20, MESSAGE_TEXT_FORMATTED);
+        messageWidget = new EditBox(font, 310, 20, MESSAGE_TEXT_FORMATTED);
         messageWidget.setMaxLength(Integer.MAX_VALUE);
-        messageWidget.setChangedListener(s -> {
+        messageWidget.setResponder(s -> {
             if (s.startsWith("/")) {
                 commandMessageWidget.setMessage(MESSAGE_TEXT);
             } else {
@@ -116,39 +116,39 @@ public class ChatKeyScreen extends SettingsScreen {
 
             updateChildren();
         });
-        messageWidget.setText(message);
+        messageWidget.setValue(message);
 
-        DirectionalLayoutWidget nameLayout = DirectionalLayoutWidget.horizontal().spacing(10);
-        nameLayout.add(nameWidget);
-        nameLayout.add(commandMessageWidget);
+        LinearLayout nameLayout = LinearLayout.horizontal().spacing(10);
+        nameLayout.addChild(nameWidget);
+        nameLayout.addChild(commandMessageWidget);
 
-        top.add(nameLayout);
-        bottom.add(messageWidget);
+        top.addChild(nameLayout);
+        bottom.addChild(messageWidget);
 
-        body.add(top);
-        body.add(bottom);
+        body.addChild(top);
+        body.addChild(bottom);
 
         setInitialFocus(messageWidget);
     }
 
     public void updateChildren() {
         try {
-            message = messageWidget.getText();
-            name = nameWidget.getText();
-            doneButton.active = !messageWidget.getText().isEmpty() && !nameWidget.getText().isEmpty();
+            message = messageWidget.getValue();
+            name = nameWidget.getValue();
+            doneButton.active = !messageWidget.getValue().isEmpty() && !nameWidget.getValue().isEmpty();
         } catch (NullPointerException ignored) {
         }
     }
 
     @Override
-    public boolean keyPressed(KeyInput input) {
+    public boolean keyPressed(KeyEvent input) {
         if (getFocused() == null || getFocused() == nameWidget || getFocused() == messageWidget) {
-            if (input.getKeycode() == GLFW.GLFW_KEY_DELETE) {
+            if (input.input() == GLFW.GLFW_KEY_DELETE) {
                 deleteButton.onPress(input);
                 return true;
             }
 
-            if (input.getKeycode() == GLFW.GLFW_KEY_ENTER) {
+            if (input.input() == GLFW.GLFW_KEY_ENTER) {
                 doneButton.onPress(input);
                 return true;
             }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keySettings/EquipElytraSettings.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keySettings/EquipElytraSettings.java
@@ -1,14 +1,14 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen.keySettings;
 
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.tooltip.Tooltip;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.client.gui.widget.TextWidget;
-import net.minecraft.item.Items;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Language;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.locale.Language;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Items;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.config.EquipElytraConfig;
 import net.sn0wix_.notEnoughKeybinds.gui.SettingsScreen;
@@ -16,27 +16,27 @@ import net.sn0wix_.notEnoughKeybinds.gui.screen.INotEKLayoutTemplate;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 
 public class EquipElytraSettings extends SettingsScreen implements INotEKLayoutTemplate {
-    public ButtonWidget swapFirstButton;
-    public ButtonWidget swapSecondButton;
-    public ButtonWidget chooseElytraButton;
-    public ButtonWidget chooseChestplateButton;
-    public ButtonWidget acceptCurseOfVanishingButton;
-    public ButtonWidget acceptCurseOfBindingButton;
-    public ButtonWidget enterFlightButton;
+    public Button swapFirstButton;
+    public Button swapSecondButton;
+    public Button chooseElytraButton;
+    public Button chooseChestplateButton;
+    public Button acceptCurseOfVanishingButton;
+    public Button acceptCurseOfBindingButton;
+    public Button enterFlightButton;
 
-    public ButtonWidget fireworkDurationButton;
-    public ButtonWidget canExplodeButton;
-    public ButtonWidget equipSlotButton;
-    public ButtonWidget fireworkEquipMode;
-    public ButtonWidget swapBackOldItemButton;
-    public ButtonWidget useRocket;
-    public ButtonWidget selectRocket;
+    public Button fireworkDurationButton;
+    public Button canExplodeButton;
+    public Button equipSlotButton;
+    public Button fireworkEquipMode;
+    public Button swapBackOldItemButton;
+    public Button useRocket;
+    public Button selectRocket;
 
-    public DirectionalLayoutWidget leftWidget = getColumnWidget();
-    public DirectionalLayoutWidget rightWidget = getColumnWidget();
+    public LinearLayout leftWidget = getColumnWidget();
+    public LinearLayout rightWidget = getColumnWidget();
 
     public EquipElytraSettings(Screen parent) {
-        super(parent, Text.translatable(TextUtils.getSettingsTranslationKey("equip_elytra")));
+        super(parent, Component.translatable(TextUtils.getSettingsTranslationKey("equip_elytra")));
     }
 
     @Override
@@ -46,153 +46,153 @@ public class EquipElytraSettings extends SettingsScreen implements INotEKLayoutT
     }
 
     public void initButtons() {
-        leftWidget.add(new TextWidget(TextUtils.getText("elytra_and_chestplate").copy().formatted(Formatting.GRAY), textRenderer));
-        rightWidget.add(new TextWidget(TextUtils.getText("fireworks").copy().formatted(Formatting.GRAY), textRenderer));
+        leftWidget.addChild(new StringWidget(TextUtils.getText("elytra_and_chestplate").copy().withStyle(ChatFormatting.GRAY), font));
+        rightWidget.addChild(new StringWidget(TextUtils.getText("fireworks").copy().withStyle(ChatFormatting.GRAY), font));
 
         //Elytra
-        swapFirstButton = ButtonWidget.builder(Text.empty(), button -> {
+        swapFirstButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.cycleSwapFirst();
             updateButtons();
         }).size(150, 20).tooltip(TextUtils.getTooltip("swap_first.elytra")).build();
-        leftWidget.add(swapFirstButton);
+        leftWidget.addChild(swapFirstButton);
 
-        swapSecondButton = ButtonWidget.builder(Text.empty(), button -> {
+        swapSecondButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond;
             updateButtons();
         }).size(150, 20).build();
-        leftWidget.add(swapSecondButton);
+        leftWidget.addChild(swapSecondButton);
 
-        chooseElytraButton = ButtonWidget.builder(Text.empty(), button -> {
+        chooseElytraButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestElytra = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestElytra;
             updateButtons();
-        }).size(150, 20).tooltip(Tooltip.of(Text.translatable(TextUtils.getTranslationKey("choose", true), Language.getInstance().get(Items.ELYTRA.getTranslationKey())))).build();
-        leftWidget.add(chooseElytraButton);
+        }).size(150, 20).tooltip(Tooltip.create(Component.translatable(TextUtils.getTranslationKey("choose", true), Language.getInstance().getOrDefault(Items.ELYTRA.getDescriptionId())))).build();
+        leftWidget.addChild(chooseElytraButton);
 
-        chooseChestplateButton = ButtonWidget.builder(Text.empty(), button -> {
+        chooseChestplateButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestChestplate = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestChestplate;
             updateButtons();
-        }).size(150, 20).tooltip(Tooltip.of(Text.translatable(TextUtils.getTranslationKey("choose", true), Language.getInstance().get(TextUtils.getTranslationKey("chestplate"))))).build();
-        leftWidget.add(chooseChestplateButton);
+        }).size(150, 20).tooltip(Tooltip.create(Component.translatable(TextUtils.getTranslationKey("choose", true), Language.getInstance().getOrDefault(TextUtils.getTranslationKey("chestplate"))))).build();
+        leftWidget.addChild(chooseChestplateButton);
 
-        acceptCurseOfVanishingButton = ButtonWidget.builder(Text.empty(), button -> {
+        acceptCurseOfVanishingButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfVanishing = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfVanishing;
             updateButtons();
-        }).size(150, 20).tooltip(TextUtils.getTooltip("accept_enchantment", Language.getInstance().get("enchantment.minecraft.vanishing_curse"))).build();
-        leftWidget.add(acceptCurseOfVanishingButton);
+        }).size(150, 20).tooltip(TextUtils.getTooltip("accept_enchantment", Language.getInstance().getOrDefault("enchantment.minecraft.vanishing_curse"))).build();
+        leftWidget.addChild(acceptCurseOfVanishingButton);
 
-        acceptCurseOfBindingButton = ButtonWidget.builder(Text.empty(), button -> {
+        acceptCurseOfBindingButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfBinding = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfBinding;
             updateButtons();
-        }).size(150, 20).tooltip(TextUtils.getTooltip("accept_enchantment", Language.getInstance().get("enchantment.minecraft.binding_curse"))).build();
-        leftWidget.add(acceptCurseOfBindingButton);
+        }).size(150, 20).tooltip(TextUtils.getTooltip("accept_enchantment", Language.getInstance().getOrDefault("enchantment.minecraft.binding_curse"))).build();
+        leftWidget.addChild(acceptCurseOfBindingButton);
 
-        enterFlightButton = ButtonWidget.builder(Text.empty(), button -> {
+        enterFlightButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.enterFlightMode = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.enterFlightMode;
             updateButtons();
         }).size(150, 20).tooltip(TextUtils.getTooltip("toggle_flight")).build();
-        leftWidget.add(enterFlightButton);
+        leftWidget.addChild(enterFlightButton);
 
         //Fireworks
-        fireworkEquipMode = ButtonWidget.builder(Text.empty(), button -> {
+        fireworkEquipMode = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.cycleUseMode();
             updateButtons();
         }).size(150, 20).tooltip(TextUtils.getTooltip("firework.equip")).build();
-        rightWidget.add(fireworkEquipMode);
+        rightWidget.addChild(fireworkEquipMode);
 
-        equipSlotButton = ButtonWidget.builder(Text.empty(), button -> {
+        equipSlotButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.cycleSlot();
             updateButtons();
         }).size(150, 20).tooltip(TextUtils.getTooltip("firework.slot")).build();
-        rightWidget.add(equipSlotButton);
+        rightWidget.addChild(equipSlotButton);
 
 
-        DirectionalLayoutWidget widget = DirectionalLayoutWidget.horizontal().spacing(2);
+        LinearLayout widget = LinearLayout.horizontal().spacing(2);
 
-        useRocket = ButtonWidget.builder(Text.empty(), button -> {
+        useRocket = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.useRocket = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.useRocket;
             updateButtons();
         }).size(74, 20).tooltip(TextUtils.getTooltip("firework.use")).build();
-        widget.add(useRocket);
+        widget.addChild(useRocket);
 
-        selectRocket = ButtonWidget.builder(Text.empty(), button -> {
+        selectRocket = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.selectRocket = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.selectRocket;
             updateButtons();
         }).size(74, 20).tooltip(TextUtils.getTooltip("firework.select")).build();
-        widget.add(selectRocket);
+        widget.addChild(selectRocket);
 
-        rightWidget.add(widget);
+        rightWidget.addChild(widget);
 
-        swapBackOldItemButton = ButtonWidget.builder(Text.empty(), button -> {
+        swapBackOldItemButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapBackOldItem = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapBackOldItem;
             updateButtons();
         }).size(150, 20).tooltip(TextUtils.getTooltip("swap_old")).build();
-        rightWidget.add(swapBackOldItemButton);
+        rightWidget.addChild(swapBackOldItemButton);
 
-        fireworkDurationButton = ButtonWidget.builder(Text.empty(), button -> {
+        fireworkDurationButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.longestDuration = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.longestDuration;
             updateButtons();
         }).size(150, 20).tooltip(TextUtils.getTooltip("firework.duration")).build();
-        rightWidget.add(fireworkDurationButton);
+        rightWidget.addChild(fireworkDurationButton);
 
-        canExplodeButton = ButtonWidget.builder(Text.empty(), button -> {
+        canExplodeButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.canExplode = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.canExplode;
             updateButtons();
         }).size(150, 20).build();
-        rightWidget.add(canExplodeButton);
+        rightWidget.addChild(canExplodeButton);
 
         updateButtons();
     }
 
     public void updateButtons() {
         swapFirstButton.setMessage(TextUtils.getCombinedTranslation(TextUtils.getText("swap_first"),
-                Text.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getSwapTranslationKey())));
+                Component.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getSwapTranslationKey())));
 
         swapSecondButton.active = !NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapFirst.equals("off");
         swapSecondButton.setMessage(TextUtils.getCombinedTranslation(TextUtils.getText("swap_second"),
-                Text.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
-        swapSecondButton.setTooltip(Tooltip.of(swapSecondButton.active ? Text.translatable(TextUtils.getTranslationKey("swap_second", true),
-                Language.getInstance().get(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getSwapTranslationKey()),
-                Language.getInstance().get(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getSwapTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getOppositeSwap()))) : Text.empty()));
+                Component.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
+        swapSecondButton.setTooltip(Tooltip.create(swapSecondButton.active ? Component.translatable(TextUtils.getTranslationKey("swap_second", true),
+                Language.getInstance().getOrDefault(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getSwapTranslationKey()),
+                Language.getInstance().getOrDefault(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getSwapTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getOppositeSwap()))) : Component.empty()));
 
-        chooseElytraButton.setMessage(Text.translatable(TextUtils.getTranslationKey("pick"),
-                Language.getInstance().get(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestElytra ? "best" : "first_found")),
-                Language.getInstance().get(Items.ELYTRA.getTranslationKey())));
+        chooseElytraButton.setMessage(Component.translatable(TextUtils.getTranslationKey("pick"),
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestElytra ? "best" : "first_found")),
+                Language.getInstance().getOrDefault(Items.ELYTRA.getDescriptionId())));
 
-        chooseChestplateButton.setMessage(Text.translatable(TextUtils.getTranslationKey("pick"),
-                Language.getInstance().get(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestChestplate ? "best" : "first_found")),
-                Language.getInstance().get(TextUtils.getTranslationKey("chestplate"))));
+        chooseChestplateButton.setMessage(Component.translatable(TextUtils.getTranslationKey("pick"),
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestChestplate ? "best" : "first_found")),
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey("chestplate"))));
 
         acceptCurseOfBindingButton.setMessage(TextUtils.getText("accept",
-                Language.getInstance().get("enchantment.minecraft.binding_curse"),
-                Language.getInstance().get(TextUtils.getTranslationKey(String.valueOf(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfBinding)))));
+                Language.getInstance().getOrDefault("enchantment.minecraft.binding_curse"),
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(String.valueOf(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfBinding)))));
 
         acceptCurseOfVanishingButton.setMessage(TextUtils.getText("accept",
-                Language.getInstance().get("enchantment.minecraft.vanishing_curse"),
-                Language.getInstance().get(TextUtils.getTranslationKey(String.valueOf(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfVanishing)))));
+                Language.getInstance().getOrDefault("enchantment.minecraft.vanishing_curse"),
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(String.valueOf(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfVanishing)))));
 
         enterFlightButton.setMessage(TextUtils.getCombinedTranslation(TextUtils.getText("enter_flight_mode"),
-                Text.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.enterFlightMode ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
+                Component.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.enterFlightMode ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
 
 
-        fireworkDurationButton.setMessage(Text.translatable(TextUtils.getTranslationKey("firework.duration"),
-                Language.getInstance().get(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.longestDuration ? "longest" : "shortest"))));
+        fireworkDurationButton.setMessage(Component.translatable(TextUtils.getTranslationKey("firework.duration"),
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.longestDuration ? "longest" : "shortest"))));
 
         canExplodeButton.setMessage(TextUtils.getText("firework.can_explode",
-                Language.getInstance().get(TextUtils.getTranslationKey(String.valueOf(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.canExplode)))));
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(String.valueOf(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.canExplode)))));
 
         equipSlotButton.setMessage(TextUtils.getText("firework.slot", String.valueOf(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.fireworkSwapSlot + 1)));
 
         fireworkEquipMode.setMessage(TextUtils.getText("firework.equip",
-                Language.getInstance().get(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getUseModeString()))));
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.getUseModeString()))));
 
         swapBackOldItemButton.setMessage(TextUtils.getText("swap_old",
-                Text.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapBackOldItem ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
+                Component.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapBackOldItem ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
 
         useRocket.setMessage(TextUtils.getText("firework.use",
-                Text.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.useRocket ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
+                Component.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.useRocket ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
 
         selectRocket.setMessage(TextUtils.getText("firework.select",
-                Text.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.selectRocket ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
+                Component.translatable(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.selectRocket ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
 
         equipSlotButton.active = NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode == 1;
         useRocket.active = NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode >= 1 && NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode <= 3;

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keySettings/SwapTotemShieldSettings.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keySettings/SwapTotemShieldSettings.java
@@ -1,12 +1,12 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen.keySettings;
 
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.tooltip.Tooltip;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.item.Items;
-import net.minecraft.text.Text;
-import net.minecraft.util.Language;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.locale.Language;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Items;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.config.SwapTotemShieldConfig;
 import net.sn0wix_.notEnoughKeybinds.gui.IntFieldWidget;
@@ -15,16 +15,16 @@ import net.sn0wix_.notEnoughKeybinds.gui.screen.INotEKLayoutTemplate;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 
 public class SwapTotemShieldSettings extends SettingsScreen implements INotEKLayoutTemplate {
-    public ButtonWidget swapFirstButton;
-    public ButtonWidget shieldAlgorithmButton;
-    public ButtonWidget swapSecondButton;
+    public Button swapFirstButton;
+    public Button shieldAlgorithmButton;
+    public Button swapSecondButton;
     public IntFieldWidget mendingPointsWidget;
 
-    public DirectionalLayoutWidget leftWidget = getColumnWidget();
-    public DirectionalLayoutWidget rightWidget = getColumnWidget();
+    public LinearLayout leftWidget = getColumnWidget();
+    public LinearLayout rightWidget = getColumnWidget();
 
     public SwapTotemShieldSettings(Screen parent) {
-        super(parent, Text.translatable(TextUtils.getSettingsTranslationKey("swap_totem_shield")));
+        super(parent, Component.translatable(TextUtils.getSettingsTranslationKey("swap_totem_shield")));
     }
 
     @Override
@@ -34,37 +34,37 @@ public class SwapTotemShieldSettings extends SettingsScreen implements INotEKLay
     }
 
     public void initButtons() {
-        swapFirstButton = ButtonWidget.builder(Text.empty(), button -> {
+        swapFirstButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.cycleSwapFirst();
             updateButtons();
         }).size(150, 20).tooltip(TextUtils.getTooltip("swap_first.offhand")).build();
-        leftWidget.add(swapFirstButton);
+        leftWidget.addChild(swapFirstButton);
 
-        shieldAlgorithmButton = ButtonWidget.builder(Text.empty(), button -> {
+        shieldAlgorithmButton = Button.builder(Component.empty(), button -> {
                     NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.chooseBestShield = !NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.chooseBestShield;
                     updateButtons();
                 })
                 .size(150, 20).tooltip(TextUtils.getTooltip("pick_shield")).build();
-        rightWidget.add(shieldAlgorithmButton);
+        rightWidget.addChild(shieldAlgorithmButton);
 
-        swapSecondButton = ButtonWidget.builder(Text.empty(), button -> {
+        swapSecondButton = Button.builder(Component.empty(), button -> {
             NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapSecond = !NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapSecond;
             updateButtons();
         }).size(150, 20).build();
-        leftWidget.add(swapSecondButton);
+        leftWidget.addChild(swapSecondButton);
 
-        mendingPointsWidget = new IntFieldWidget(textRenderer, 150, 20, Text.literal("mending_value"));
-        mendingPointsWidget.setText(String.valueOf(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapMendingPoints));
-        mendingPointsWidget.setChangedListener(s -> {
+        mendingPointsWidget = new IntFieldWidget(font, 150, 20, Component.literal("mending_value"));
+        mendingPointsWidget.setValue(String.valueOf(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapMendingPoints));
+        mendingPointsWidget.setResponder(s -> {
             try {
-                NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapMendingPoints = Integer.parseInt(mendingPointsWidget.getText());
+                NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapMendingPoints = Integer.parseInt(mendingPointsWidget.getValue());
             } catch (NumberFormatException ignored) {
             }
 
 
             updateButtons();
         });
-        rightWidget.add(mendingPointsWidget);
+        rightWidget.addChild(mendingPointsWidget);
 
 
         updateButtons();
@@ -72,24 +72,24 @@ public class SwapTotemShieldSettings extends SettingsScreen implements INotEKLay
 
     public void updateButtons() {
         swapFirstButton.setMessage(TextUtils.getCombinedTranslation(TextUtils.getText("swap_first"),
-                Text.translatable(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getSwapTranslationKey())));
+                Component.translatable(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getSwapTranslationKey())));
 
 
         swapSecondButton.active = !NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapFirst.equals("off");
 
         swapSecondButton.setMessage(TextUtils.getCombinedTranslation(TextUtils.getText("swap_second"),
-                Text.translatable(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapSecond ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
-        swapSecondButton.setTooltip(Tooltip.of(swapSecondButton.active ? Text.translatable(TextUtils.getTranslationKey("swap_second", true),
-                Language.getInstance().get(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getSwapTranslationKey()),
-                Language.getInstance().get(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getSwapTranslationKey(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getOppositeSwap()))) : Text.empty()));
+                Component.translatable(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapSecond ? TextUtils.getTranslationKey("on") : TextUtils.getTranslationKey("off"))));
+        swapSecondButton.setTooltip(Tooltip.create(swapSecondButton.active ? Component.translatable(TextUtils.getTranslationKey("swap_second", true),
+                Language.getInstance().getOrDefault(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getSwapTranslationKey()),
+                Language.getInstance().getOrDefault(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getSwapTranslationKey(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getOppositeSwap()))) : Component.empty()));
 
-        shieldAlgorithmButton.setMessage(Text.translatable(TextUtils.getTranslationKey("pick"),
-                Language.getInstance().get(TextUtils.getTranslationKey(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.chooseBestShield ? "best" : "first_found")),
-                Language.getInstance().get(Items.SHIELD.getTranslationKey())));
-        shieldAlgorithmButton.setTooltip(Tooltip.of(Text.translatable(TextUtils.getTranslationKey("choose", true), Language.getInstance().get(Items.SHIELD.getTranslationKey()))));
+        shieldAlgorithmButton.setMessage(Component.translatable(TextUtils.getTranslationKey("pick"),
+                Language.getInstance().getOrDefault(TextUtils.getTranslationKey(NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.chooseBestShield ? "best" : "first_found")),
+                Language.getInstance().getOrDefault(Items.SHIELD.getDescriptionId())));
+        shieldAlgorithmButton.setTooltip(Tooltip.create(Component.translatable(TextUtils.getTranslationKey("choose", true), Language.getInstance().getOrDefault(Items.SHIELD.getDescriptionId()))));
 
         mendingPointsWidget.visible = NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.chooseBestShield;
-        mendingPointsWidget.setTooltip(Tooltip.of(Text.translatable(TextUtils.getTranslationKey("mending_points", true), NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapMendingPoints)));
+        mendingPointsWidget.setTooltip(Tooltip.create(Component.translatable(TextUtils.getTranslationKey("mending_points", true), NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapMendingPoints)));
     }
 
     @Override

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keybindsScreen/ControlsListWidget.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keybindsScreen/ControlsListWidget.java
@@ -3,25 +3,25 @@ package net.sn0wix_.notEnoughKeybinds.gui.screen.keybindsScreen;
 import com.google.common.collect.ImmutableList;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.navigation.GuiNavigation;
-import net.minecraft.client.gui.navigation.GuiNavigationPath;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.gui.screen.narration.NarrationPart;
-import net.minecraft.client.gui.tooltip.Tooltip;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.ElementListWidget;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.text.MutableText;
-import net.minecraft.text.Text;
-import net.minecraft.util.Colors;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.Language;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ComponentPath;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.ContainerObjectSelectionList;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.navigation.FocusNavigationEvent;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.locale.Language;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.CommonColors;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.gui.ParentScreenBlConsumer;
 import net.sn0wix_.notEnoughKeybinds.gui.TexturedButtonWidget;
@@ -37,11 +37,11 @@ import java.util.List;
 import java.util.function.Supplier;
 
 @Environment(EnvType.CLIENT)
-public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Entry> {
+public class ControlsListWidget extends ContainerObjectSelectionList<ControlsListWidget.Entry> {
     public final NotEKSettingsScreen parent;
     private int maxKeyNameLength;
 
-    public ControlsListWidget(NotEKSettingsScreen parent, MinecraftClient client) {
+    public ControlsListWidget(NotEKSettingsScreen parent, Minecraft client) {
         super(client, parent.width, parent.threePartsLayout.getContentHeight(), parent.threePartsLayout.getHeaderHeight(), 20);
         this.parent = parent;
         initEntries();
@@ -51,12 +51,12 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
         this.clearEntries();
 
         NotEKKeyBindings.getCategories().forEach(category -> {
-            this.addEntry(new ControlsListWidget.CategoryEntry(Text.translatable(category.getTranslationKey()), category));
+            this.addEntry(new ControlsListWidget.CategoryEntry(Component.translatable(category.getTranslationKey()), category));
 
             for (INotEKKeybinding keybinding : category.getKeyBindings()) {
-                Text text = keybinding.getSettingsDisplayName();
+                Component text = keybinding.getSettingsDisplayName();
 
-                int textWidth = client.textRenderer.getWidth(text);
+                int textWidth = minecraft.font.width(text);
                 if (textWidth > this.maxKeyNameLength) {
                     this.maxKeyNameLength = textWidth;
                 }
@@ -71,7 +71,7 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
     }
 
     public void update() {
-        KeyBinding.updateKeysByCode();
+        KeyMapping.resetMapping();
         this.updateChildren();
     }
 
@@ -85,70 +85,70 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
     }
 
     @Override
-    protected int getScrollbarX() {
+    protected int scrollBarX() {
         return this.getX() + this.width / 2 - 340 / 2 + 340 + 10;
     }
 
     //Entries
     @Environment(EnvType.CLIENT)
     public class CategoryEntry extends ControlsListWidget.Entry {
-        final Text text;
+        final Component text;
         private final int textWidth;
-        private final ButtonWidget resetCategoryButton;
+        private final Button resetCategoryButton;
 
-        public CategoryEntry(Text text, KeybindCategory category) {
+        public CategoryEntry(Component text, KeybindCategory category) {
             this.text = text;
-            this.textWidth = ControlsListWidget.this.client.textRenderer.getWidth(this.text);
+            this.textWidth = ControlsListWidget.this.minecraft.font.width(this.text);
 
-            resetCategoryButton = ButtonWidget.builder(TextUtils.getText("reset_category"), button ->
-                            client.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(parent, client1 -> {
+            resetCategoryButton = Button.builder(TextUtils.getText("reset_category"), button ->
+                            minecraft.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(parent, client1 -> {
                                 for (int i = 0; i < category.getKeyBindings().length; i++) {
                                     category.getKeyBindings()[i].setAndSaveKeyBinding(category.getKeyBindings()[i].getDefaultKey());
                                 }
-                            }, true), Text.translatable(TextUtils.getTranslationKey("reset_category.confirm"), Language.getInstance().get(category.getTranslationKey())))))
+                            }, true), Component.translatable(TextUtils.getTranslationKey("reset_category.confirm"), Language.getInstance().getOrDefault(category.getTranslationKey())))))
                     .size(85, 16).build();
         }
 
         @Override
-        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
-            assert ControlsListWidget.this.client.currentScreen != null;
-            context.drawText(
-                    ControlsListWidget.this.client.textRenderer,
+        public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            assert ControlsListWidget.this.minecraft.screen != null;
+            context.text(
+                    ControlsListWidget.this.minecraft.font,
                     this.text,
                     ControlsListWidget.this.width / 2 - this.textWidth / 2,
                     getContentY() + getContentHeight() - 9 - 1,
-                    Colors.WHITE,
+                    CommonColors.WHITE,
                     false
             );
 
-            resetCategoryButton.setWidth(client.textRenderer.getWidth(TextUtils.getText("reset_category")) + 6);
+            resetCategoryButton.setWidth(minecraft.font.width(TextUtils.getText("reset_category")) + 6);
             resetCategoryButton.setX((ControlsListWidget.this.width / 2) - maxKeyNameLength - 2);
             resetCategoryButton.setY(getContentY() + 2);
-            resetCategoryButton.render(context, mouseX, mouseY, deltaTicks);
+            resetCategoryButton.extractRenderState(context, mouseX, mouseY, deltaTicks);
         }
 
         @Nullable
         @Override
-        public GuiNavigationPath getNavigationPath(GuiNavigation navigation) {
+        public ComponentPath nextFocusPath(FocusNavigationEvent navigation) {
             return null;
         }
 
         @Override
-        public List<? extends Element> children() {
+        public List<? extends GuiEventListener> children() {
             return List.of(resetCategoryButton);
         }
 
         @Override
-        public List<? extends Selectable> selectableChildren() {
-            return ImmutableList.of(new Selectable() {
+        public List<? extends NarratableEntry> narratables() {
+            return ImmutableList.of(new NarratableEntry() {
                 @Override
-                public Selectable.SelectionType getType() {
-                    return Selectable.SelectionType.HOVERED;
+                public NarratableEntry.NarrationPriority narrationPriority() {
+                    return NarratableEntry.NarrationPriority.HOVERED;
                 }
 
                 @Override
-                public void appendNarrations(NarrationMessageBuilder builder) {
-                    builder.put(NarrationPart.TITLE, CategoryEntry.this.text);
+                public void updateNarration(NarrationElementOutput builder) {
+                    builder.add(NarratedElementType.TITLE, CategoryEntry.this.text);
                 }
             });
         }
@@ -159,52 +159,52 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
     }
 
     @Environment(EnvType.CLIENT)
-    public class AddNewKeyButtonEntry extends Entry {
-        public final ButtonWidget button;
+    public class AddNewKeyButtonEntry extends net.sn0wix_.notEnoughKeybinds.gui.screen.keybindsScreen.ControlsListWidget.Entry {
+        public final Button button;
         public final String translationKey;
 
         public AddNewKeyButtonEntry(Screen screen, String translationKey) {
-            button = ButtonWidget.builder(Text.translatable(translationKey), button1 ->
-                    MinecraftClient.getInstance().setScreen(screen)
+            button = Button.builder(Component.translatable(translationKey), button1 ->
+                    Minecraft.getInstance().setScreen(screen)
             ).size(200, 20).build();
 
             this.translationKey = translationKey;
         }
 
         @Override
-        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
-            int resetButtonPos = ControlsListWidget.this.getScrollbarX() - 50 - 10;
+        public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            int resetButtonPos = ControlsListWidget.this.scrollBarX() - 50 - 10;
             int editButtonPos = resetButtonPos - 5 - 75;
 
 
-            int resetCategoryButtonWidth = client.textRenderer.getWidth(TextUtils.getText("reset_category")) + 6;
+            int resetCategoryButtonWidth = minecraft.font.width(TextUtils.getText("reset_category")) + 6;
             int resetCategoryButtonPos = (ControlsListWidget.this.width / 2) - maxKeyNameLength - 2;
 
             //Math.abs(((ControlsListWidget.this.width / 2) - maxKeyNameLength - 2) - 2 * (resetCategoryButtonWidth + resetCategoryButtonPos + 10))
             int width = resetButtonPos - resetCategoryButtonWidth - resetCategoryButtonPos - 10;
 
-            button.setDimensionsAndPosition(
+            button.setRectangle(
                     width,
                     20, resetButtonPos - 5 - width, getContentY() + 2);
-            button.render(context, mouseX, mouseY, deltaTicks);
+            button.extractRenderState(context, mouseX, mouseY, deltaTicks);
         }
 
         @Override
-        public List<? extends Element> children() {
+        public List<? extends GuiEventListener> children() {
             return List.of(button);
         }
 
         @Override
-        public List<? extends Selectable> selectableChildren() {
-            return List.of(new Selectable() {
+        public List<? extends NarratableEntry> narratables() {
+            return List.of(new NarratableEntry() {
                 @Override
-                public SelectionType getType() {
-                    return SelectionType.HOVERED;
+                public NarrationPriority narrationPriority() {
+                    return NarrationPriority.HOVERED;
                 }
 
                 @Override
-                public void appendNarrations(NarrationMessageBuilder builder) {
-                    builder.put(NarrationPart.TITLE, Text.translatable(translationKey));
+                public void updateNarration(NarrationElementOutput builder) {
+                    builder.add(NarratedElementType.TITLE, Component.translatable(translationKey));
                 }
             });
         }
@@ -217,49 +217,49 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
     @Environment(EnvType.CLIENT)
     public class KeyBindingEntry extends ControlsListWidget.Entry {
         private final INotEKKeybinding binding;
-        private final Text bindingName;
-        private final ButtonWidget editButton;
-        private final ButtonWidget resetButton;
-        private final ButtonWidget settingsButton;
+        private final Component bindingName;
+        private final Button editButton;
+        private final Button resetButton;
+        private final Button settingsButton;
 
         private boolean duplicate = false;
 
-        public KeyBindingEntry(INotEKKeybinding binding, Text bindingName) {
+        public KeyBindingEntry(INotEKKeybinding binding, Component bindingName) {
             this.binding = binding;
             this.bindingName = bindingName;
-            this.editButton = ButtonWidget.builder(bindingName, button -> {
+            this.editButton = Button.builder(bindingName, button -> {
                         ControlsListWidget.this.parent.selectedKeyBinding = binding;
                         ControlsListWidget.this.update();
                     })
-                    .dimensions(0, 0, 75, 20)
-                    .narrationSupplier(
+                    .bounds(0, 0, 75, 20)
+                    .createNarration(
                             textSupplier -> binding.isUnbound()
-                                    ? Text.translatable("narrator.controls.unbound", bindingName)
-                                    : Text.translatable("narrator.controls.bound", bindingName, textSupplier.get())
+                                    ? Component.translatable("narrator.controls.unbound", bindingName)
+                                    : Component.translatable("narrator.controls.bound", bindingName, textSupplier.get())
                     )
                     .build();
-            this.resetButton = ButtonWidget.builder(Text.translatable("controls.reset"), button -> {
+            this.resetButton = Button.builder(Component.translatable("controls.reset"), button -> {
                 binding.setAndSaveKeyBinding(binding.getDefaultKey());
                 ControlsListWidget.this.update();
-            }).dimensions(0, 0, 50, 20).narrationSupplier(textSupplier -> Text.translatable("narrator.controls.reset", bindingName)).build();
-            this.settingsButton = new TexturedButtonWidget(0, 0, 20, 20, Text.empty(), button -> client.setScreen(binding.getSettingsScreen(parent))
-                    , Supplier::get, Identifier.of(NotEnoughKeybinds.MOD_ID, "textures/settings.png"), 14, 14, 14, 14);
+            }).bounds(0, 0, 50, 20).createNarration(textSupplier -> Component.translatable("narrator.controls.reset", bindingName)).build();
+            this.settingsButton = new TexturedButtonWidget(0, 0, 20, 20, Component.empty(), button -> minecraft.setScreen(binding.getSettingsScreen(parent))
+                    , Supplier::get, Identifier.fromNamespaceAndPath(NotEnoughKeybinds.MOD_ID, "textures/settings.png"), 14, 14, 14, 14);
 
             this.settingsButton.setTooltip(TextUtils.getTooltip("settings"));
             this.update();
         }
 
         @Override
-        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
-            int resetButtonPos = ControlsListWidget.this.getScrollbarX() - this.resetButton.getWidth() - 10;
+        public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            int resetButtonPos = ControlsListWidget.this.scrollBarX() - this.resetButton.getWidth() - 10;
             int j = getContentY() - 2;
             int startPos = getWidth() / 2 - maxKeyNameLength;
             this.resetButton.setPosition(resetButtonPos, j);
-            this.resetButton.render(context, mouseX, mouseY, deltaTicks);
+            this.resetButton.extractRenderState(context, mouseX, mouseY, deltaTicks);
             int editButtonPos = resetButtonPos - 5 - this.editButton.getWidth();
             this.editButton.setPosition(editButtonPos, j);
-            this.editButton.render(context, mouseX, mouseY, deltaTicks);
-            context.drawTextWithShadow(ControlsListWidget.this.client.textRenderer, this.bindingName, startPos, getContentY() + getContentHeight() / 2 - 9 / 2, Colors.WHITE);
+            this.editButton.extractRenderState(context, mouseX, mouseY, deltaTicks);
+            context.text(ControlsListWidget.this.minecraft.font, this.bindingName, startPos, getContentY() + getContentHeight() / 2 - 9 / 2, CommonColors.WHITE);
             if (this.duplicate) {
                 int m = this.editButton.getX() - 6;
                 context.fill(m, getContentY() - 1, m + 3, getContentY() + getContentHeight(), -65536);
@@ -267,16 +267,16 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
 
             this.settingsButton.setX(startPos - 25);
             this.settingsButton.setY(getContentY());
-            this.settingsButton.render(context, mouseX, mouseY, deltaTicks);
+            this.settingsButton.extractRenderState(context, mouseX, mouseY, deltaTicks);
         }
 
         @Override
-        public List<? extends Element> children() {
+        public List<? extends GuiEventListener> children() {
             return List.of(this.editButton, this.resetButton, this.settingsButton);
         }
 
         @Override
-        public List<? extends Selectable> selectableChildren() {
+        public List<? extends NarratableEntry> narratables() {
             return List.of(this.editButton, this.resetButton, this.settingsButton);
         }
 
@@ -285,35 +285,35 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
             this.editButton.setMessage(this.binding.getBoundKeyLocalizedText());
             this.resetButton.active = !this.binding.isDefault();
             this.duplicate = false;
-            MutableText mutableText = Text.empty();
+            MutableComponent mutableText = Component.empty();
             if (!this.binding.isUnbound()) {
-                for (KeyBinding keyBinding : MinecraftClient.getInstance().options.allKeys) {
-                    if (!(binding instanceof F3DebugKeybinding) && keyBinding != this.binding.getBinding() && this.binding.getBinding().equals(keyBinding)) {
+                for (KeyMapping keyBinding : Minecraft.getInstance().options.keyMappings) {
+                    if (!(binding instanceof F3DebugKeybinding) && keyBinding != this.binding.getBinding() && this.binding.getBinding().same(keyBinding)) {
                         if (this.duplicate) {
                             mutableText.append(", ");
                         }
 
                         this.duplicate = true;
-                        mutableText.append(Text.translatable(keyBinding.getId()));
+                        mutableText.append(Component.translatable(keyBinding.getName()));
                     }
                 }
             }
 
             if (this.duplicate) {
                 this.editButton
-                        .setMessage(Text.literal("[ ").append(this.editButton.getMessage().copy().formatted(Formatting.WHITE)).append(" ]").formatted(Formatting.RED));
-                this.editButton.setTooltip(Tooltip.of(Text.translatable("controls.keybinds.duplicateKeybinds", mutableText)));
+                        .setMessage(Component.literal("[ ").append(this.editButton.getMessage().copy().withStyle(ChatFormatting.WHITE)).append(" ]").withStyle(ChatFormatting.RED));
+                this.editButton.setTooltip(Tooltip.create(Component.translatable("controls.keybinds.duplicateKeybinds", mutableText)));
             } else {
-                this.editButton.setTooltip(binding.getTooltip().getString().isEmpty() ? null : Tooltip.of(binding.getTooltip()));
+                this.editButton.setTooltip(binding.getTooltip().getString().isEmpty() ? null : Tooltip.create(binding.getTooltip()));
             }
 
             if (ControlsListWidget.this.parent.selectedKeyBinding == this.binding) {
                 this.editButton
                         .setMessage(
-                                Text.literal("> ")
-                                        .append(this.editButton.getMessage().copy().formatted(Formatting.WHITE, Formatting.UNDERLINE))
+                                Component.literal("> ")
+                                        .append(this.editButton.getMessage().copy().withStyle(ChatFormatting.WHITE, ChatFormatting.UNDERLINE))
                                         .append(" <")
-                                        .formatted(Formatting.YELLOW)
+                                        .withStyle(ChatFormatting.YELLOW)
                         );
             }
             this.settingsButton.visible = binding.getSettingsScreen(parent) != null;
@@ -322,7 +322,7 @@ public class ControlsListWidget extends ElementListWidget<ControlsListWidget.Ent
 
 
     @Environment(EnvType.CLIENT)
-    public abstract static class Entry extends ElementListWidget.Entry<ControlsListWidget.Entry> {
+    public abstract static class Entry extends ContainerObjectSelectionList.Entry<ControlsListWidget.Entry> {
         abstract void update();
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keybindsScreen/ModKeybindsButton.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keybindsScreen/ModKeybindsButton.java
@@ -2,60 +2,60 @@ package net.sn0wix_.notEnoughKeybinds.gui.screen.keybindsScreen;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.RenderPipelines;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
-import net.minecraft.client.gui.screen.narration.NarrationPart;
-import net.minecraft.client.gui.screen.option.ControlsListWidget;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarratedElementType;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsList;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.mixin.ControlsListWidgetAccessor;
 
 import java.util.List;
 
 @Environment(EnvType.CLIENT)
-public class ModKeybindsButton extends ControlsListWidget.CategoryEntry {
-    public final ButtonWidget button;
+public class ModKeybindsButton extends KeyBindsList.CategoryEntry {
+    public final Button button;
 
-    public ModKeybindsButton(ControlsListWidget widget) {
-        widget.super(new KeyBinding.Category(Identifier.of("")));
+    public ModKeybindsButton(KeyBindsList widget) {
+        widget.super(new KeyMapping.Category(Identifier.parse("")));
 
-        button = ButtonWidget.builder(Text.translatable("settings." + NotEnoughKeybinds.MOD_ID), button1 ->
-                MinecraftClient.getInstance().setScreen(new NotEKSettingsScreen(((ControlsListWidgetAccessor) widget).getParent()))
+        button = Button.builder(Component.translatable("settings." + NotEnoughKeybinds.MOD_ID), button1 ->
+                Minecraft.getInstance().setScreen(new NotEKSettingsScreen(((ControlsListWidgetAccessor) widget).getParent()))
         ).size(340, 20).build();
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+    public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
         button.setWidth(getContentWidth() + 2);
         button.setPosition(getContentX(), getContentY());
-        button.render(context, mouseX, mouseY, deltaTicks);
+        button.extractRenderState(context, mouseX, mouseY, deltaTicks);
 
-        context.drawTexture(RenderPipelines.GUI_TEXTURED, NotEnoughKeybinds.ICON, getContentX() + 340 / 2 - MinecraftClient.getInstance().textRenderer.getWidth(button.getMessage()) / 2 - 20, getContentY(), 0, 0, 0, 18, 18, 18, 18);
+        context.blit(RenderPipelines.GUI_TEXTURED, NotEnoughKeybinds.ICON, getContentX() + 340 / 2 - Minecraft.getInstance().font.width(button.getMessage()) / 2 - 20, getContentY(), 0, 0, 0, 18, 18, 18, 18);
     }
 
     @Override
-    public List<? extends Element> children() {
+    public List<? extends GuiEventListener> children() {
         return List.of(button);
     }
 
     @Override
-    public List<? extends Selectable> selectableChildren() {
-        return List.of(new Selectable() {
+    public List<? extends NarratableEntry> narratables() {
+        return List.of(new NarratableEntry() {
             @Override
-            public SelectionType getType() {
-                return SelectionType.HOVERED;
+            public NarrationPriority narrationPriority() {
+                return NarrationPriority.HOVERED;
             }
 
             @Override
-            public void appendNarrations(NarrationMessageBuilder builder) {
-                builder.put(NarrationPart.TITLE, Text.of("not enough keybinds settings"));
+            public void updateNarration(NarrationElementOutput builder) {
+                builder.add(NarratedElementType.TITLE, Component.nullToEmpty("not enough keybinds settings"));
             }
         });
     }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keybindsScreen/NotEKSettingsScreen.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/keybindsScreen/NotEKSettingsScreen.java
@@ -1,14 +1,14 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen.keybindsScreen;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.gui.Click;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
 import net.minecraft.util.Util;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.gui.SettingsScreen;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.BasicLayoutWidget;
@@ -26,33 +26,33 @@ public class NotEKSettingsScreen extends SettingsScreen {
 
 
     public NotEKSettingsScreen(Screen parent) {
-        super(parent, Text.translatable("settings." + NotEnoughKeybinds.MOD_ID));
+        super(parent, Component.translatable("settings." + NotEnoughKeybinds.MOD_ID));
         threePartsLayout = new BasicLayoutWidget(33, this);
     }
 
     @Override
     protected void init() {
-        controlsList = new ControlsListWidget(this, this.client);
-        controlsList.setScrollY(scrollAmount);
+        controlsList = new ControlsListWidget(this, this.minecraft);
+        controlsList.setScrollAmount(scrollAmount);
         super.init();
     }
 
     @Override
     public void initBody() {
-        this.threePartsLayout.addBody(controlsList);
+        this.threePartsLayout.addToContents(controlsList);
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        super.render(context, mouseX, mouseY, delta);
-        scrollAmount = controlsList.getScrollY();
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(context, mouseX, mouseY, delta);
+        scrollAmount = controlsList.scrollAmount();
     }
 
     @Override
-    public boolean mouseClicked(Click click, boolean doubled) {
+    public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
         if (this.selectedKeyBinding != null && selectedKeyBinding.getBinding() != null) {
-            assert this.client != null;
-            selectedKeyBinding.getBinding().setBoundKey(InputUtil.Type.MOUSE.createFromCode(click.button()));
+            assert this.minecraft != null;
+            selectedKeyBinding.getBinding().setKey(InputConstants.Type.MOUSE.getOrCreate(click.button()));
             this.selectedKeyBinding = null;
             this.controlsList.update();
             return true;
@@ -62,16 +62,16 @@ public class NotEKSettingsScreen extends SettingsScreen {
     }
 
     @Override
-    public boolean keyPressed(KeyInput input) {
+    public boolean keyPressed(KeyEvent input) {
         if (this.selectedKeyBinding != null) {
             if (input.key() == GLFW.GLFW_KEY_ESCAPE) {
-                selectedKeyBinding.setAndSaveKeyBinding(InputUtil.UNKNOWN_KEY);
+                selectedKeyBinding.setAndSaveKeyBinding(InputConstants.UNKNOWN);
             } else {
-                selectedKeyBinding.setAndSaveKeyBinding(InputUtil.fromKeyCode(input));
+                selectedKeyBinding.setAndSaveKeyBinding(InputConstants.getKey(input));
             }
 
             this.selectedKeyBinding = null;
-            this.lastKeyCodeUpdateTime = Util.getMeasuringTimeMs();
+            this.lastKeyCodeUpdateTime = Util.getMillis();
             this.controlsList.update();
             return true;
         } else {
@@ -80,13 +80,13 @@ public class NotEKSettingsScreen extends SettingsScreen {
     }
 
     @Override
-    public void refreshWidgetPositions() {
-        this.controlsList.position(this.width, this.threePartsLayout);
-        super.refreshWidgetPositions();
+    public void repositionElements() {
+        this.controlsList.updateSize(this.width, this.threePartsLayout);
+        super.repositionElements();
     }
 
     @Override
-    public void onDisplayed() {
+    public void added() {
         if (controlsList != null) {
             controlsList.initEntries();
             controlsList.update();

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetEditScreen.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetEditScreen.java
@@ -1,14 +1,14 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen.presets;
 
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.client.gui.widget.TextFieldWidget;
-import net.minecraft.client.gui.widget.TextWidget;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.screen.ScreenTexts;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.gui.SettingsScreen;
 import net.sn0wix_.notEnoughKeybinds.keybinds.presets.PresetLoader;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
@@ -16,24 +16,24 @@ import net.sn0wix_.notEnoughKeybinds.util.Utils;
 import org.lwjgl.glfw.GLFW;
 
 public class PresetEditScreen extends SettingsScreen {
-    public static final Text NAME_TEXT = Text.translatable(TextUtils.getTranslationKey("name")).formatted(Formatting.GRAY);
-    public static final Text DESCRIPTION_TEXT = Text.translatable(TextUtils.getTranslationKey("description")).formatted(Formatting.GRAY);
+    public static final Component NAME_TEXT = Component.translatable(TextUtils.getTranslationKey("name")).withStyle(ChatFormatting.GRAY);
+    public static final Component DESCRIPTION_TEXT = Component.translatable(TextUtils.getTranslationKey("description")).withStyle(ChatFormatting.GRAY);
 
 
     public final PresetLoader.KeybindPreset preset;
-    public TextFieldWidget nameWidget;
-    public TextFieldWidget descriptionWidget;
-    public ButtonWidget doneButton;
+    public EditBox nameWidget;
+    public EditBox descriptionWidget;
+    public Button doneButton;
 
     public String name;
     public String description;
     public boolean newPreset;
 
-    public DirectionalLayoutWidget body = DirectionalLayoutWidget.vertical().spacing(20);
+    public LinearLayout body = LinearLayout.vertical().spacing(20);
 
 
     public PresetEditScreen(Screen parent, PresetLoader.KeybindPreset preset, boolean newPreset) {
-        super(parent, Text.translatable(TextUtils.getSettingsTranslationKey(newPreset ? "preset.new" : "preset")));
+        super(parent, Component.translatable(TextUtils.getSettingsTranslationKey(newPreset ? "preset.new" : "preset")));
         this.preset = preset;
         this.name = preset.getName();
         this.description = preset.getDescription();
@@ -43,54 +43,54 @@ public class PresetEditScreen extends SettingsScreen {
     @Override
     protected void initBody() {
         initButtons();
-        threePartsLayout.addBody(body);
+        threePartsLayout.addToContents(body);
     }
 
     @Override
     public void initFooter() {
-        DirectionalLayoutWidget directionalLayoutWidget = this.threePartsLayout.addFooter(DirectionalLayoutWidget.horizontal().spacing(8));
-        directionalLayoutWidget.add(ButtonWidget.builder(ScreenTexts.BACK, button -> client.setScreen(parent)
+        LinearLayout directionalLayoutWidget = this.threePartsLayout.addToFooter(LinearLayout.horizontal().spacing(8));
+        directionalLayoutWidget.addChild(Button.builder(CommonComponents.GUI_BACK, button -> minecraft.setScreen(parent)
         ).build());
 
-        directionalLayoutWidget.add(doneButton);
+        directionalLayoutWidget.addChild(doneButton);
     }
 
     public void initButtons() {
-        doneButton = ButtonWidget.builder(ScreenTexts.DONE, button -> {
-            preset.setName(nameWidget.getText());
-            preset.setDescription(descriptionWidget.getText());
+        doneButton = Button.builder(CommonComponents.GUI_DONE, button -> {
+            preset.setName(nameWidget.getValue());
+            preset.setDescription(descriptionWidget.getValue());
             PresetLoader.writePreset(preset, preset.getContent().isEmpty() ? Utils.bindingsToList(true) : preset.getContent());
             PresetLoader.reload(false);
 
             if (parent instanceof PresetsSettingScreen presetsSettingScreen) {
-                presetsSettingScreen.clearAndInit();
+                presetsSettingScreen.rebuildWidgets();
             }
 
             Utils.showToastNotification(TextUtils.getText("preset." + (newPreset ? "create" : "edit") + ".toast", preset.getName()));
 
-            assert client != null;
-            client.setScreen(parent);
+            assert minecraft != null;
+            minecraft.setScreen(parent);
         }).build();
 
-        DirectionalLayoutWidget top = DirectionalLayoutWidget.vertical().spacing(2);
-        DirectionalLayoutWidget bottom = DirectionalLayoutWidget.vertical().spacing(2);
+        LinearLayout top = LinearLayout.vertical().spacing(2);
+        LinearLayout bottom = LinearLayout.vertical().spacing(2);
 
-        top.add(new TextWidget(200, 20, NAME_TEXT, textRenderer));
-        nameWidget = new TextFieldWidget(textRenderer, 310, 20, NAME_TEXT);
-        nameWidget.setChangedListener(s -> updateChildren());
+        top.addChild(new StringWidget(200, 20, NAME_TEXT, font));
+        nameWidget = new EditBox(font, 310, 20, NAME_TEXT);
+        nameWidget.setResponder(s -> updateChildren());
         nameWidget.setMaxLength(Integer.MAX_VALUE);
-        nameWidget.setText(name);
-        top.add(nameWidget);
+        nameWidget.setValue(name);
+        top.addChild(nameWidget);
 
 
-        bottom.add(new TextWidget(200, 20, DESCRIPTION_TEXT, textRenderer));
-        descriptionWidget = new TextFieldWidget(textRenderer, 310, 20, DESCRIPTION_TEXT);
+        bottom.addChild(new StringWidget(200, 20, DESCRIPTION_TEXT, font));
+        descriptionWidget = new EditBox(font, 310, 20, DESCRIPTION_TEXT);
         descriptionWidget.setMaxLength(Integer.MAX_VALUE);
-        descriptionWidget.setText(description);
-        bottom.add(descriptionWidget);
+        descriptionWidget.setValue(description);
+        bottom.addChild(descriptionWidget);
 
-        body.add(top);
-        body.add(bottom);
+        body.addChild(top);
+        body.addChild(bottom);
 
         setInitialFocus(nameWidget);
         updateChildren();
@@ -98,22 +98,22 @@ public class PresetEditScreen extends SettingsScreen {
 
     public void updateChildren() {
         try {
-            description = descriptionWidget.getText();
-            name = nameWidget.getText();
-            doneButton.active = !nameWidget.getText().isEmpty();
+            description = descriptionWidget.getValue();
+            name = nameWidget.getValue();
+            doneButton.active = !nameWidget.getValue().isEmpty();
         } catch (NullPointerException ignored) {
         }
     }
 
     @Override
-    public boolean keyPressed(KeyInput input) {
+    public boolean keyPressed(KeyEvent input) {
         if (getFocused() == null || getFocused() == descriptionWidget || getFocused() == nameWidget) {
-            if (input.getKeycode() == GLFW.GLFW_KEY_DELETE) {
-                client.setScreen(parent);
+            if (input.input() == GLFW.GLFW_KEY_DELETE) {
+                minecraft.setScreen(parent);
                 return true;
             }
 
-            if (input.getKeycode() == GLFW.GLFW_KEY_ENTER) {
+            if (input.input() == GLFW.GLFW_KEY_ENTER) {
                 doneButton.onPress(input);
                 return true;
             }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetsButton.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetsButton.java
@@ -1,44 +1,43 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen.presets;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.screen.option.ControlsListWidget;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.text.Text;
-import net.minecraft.util.Colors;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsList;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.CommonColors;
 import net.sn0wix_.notEnoughKeybinds.keybinds.presets.PresetLoader;
 import net.sn0wix_.notEnoughKeybinds.mixin.ControlsListWidgetAccessor;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 
 import java.util.List;
 
-public class PresetsButton extends ControlsListWidget.CategoryEntry {
-    public final ButtonWidget presetSettings;
-    public final TextRenderer textRenderer;
+public class PresetsButton extends KeyBindsList.CategoryEntry {
+    public final Button presetSettings;
+    public final Font textRenderer;
 
-    public PresetsButton(ControlsListWidget widget, TextRenderer renderer) {
-        widget.super(new KeyBinding.Category(Identifier.of("")));
+    public PresetsButton(KeyBindsList widget, Font renderer) {
+        widget.super(new KeyMapping.Category(Identifier.parse("")));
         this.textRenderer = renderer;
 
-        presetSettings = ButtonWidget.builder(TextUtils.getText("presets"), button1 ->
-                        MinecraftClient.getInstance().setScreen(new PresetsSettingScreen(((ControlsListWidgetAccessor) widget).getParent())))
+        presetSettings = Button.builder(TextUtils.getText("presets"), button1 ->
+                        Minecraft.getInstance().setScreen(new PresetsSettingScreen(((ControlsListWidgetAccessor) widget).getParent())))
                 .size(132, 20).build();
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+    public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
         String textToRender = TextUtils.getText("current_preset").getString() + PresetLoader.getCurrentPresetName();
 
         int x = getContentX();
 
         //location of the presets button
         int buttonPos = x + getContentWidth() / 2 - 340 / 2 + 340 - presetSettings.getWidth();
-        int textLength = textRenderer.getWidth(textToRender) + 20;
+        int textLength = textRenderer.width(textToRender) + 20;
         int padding = 5;
 
         try {
@@ -50,7 +49,7 @@ public class PresetsButton extends ControlsListWidget.CategoryEntry {
                     //the text is so large, it doesn't fit on the screen
                     StringBuilder builder = new StringBuilder();
 
-                    for (int i = 0; textRenderer.getWidth(builder + "...") <= buttonPos - padding * 2; i++) {
+                    for (int i = 0; textRenderer.width(builder + "...") <= buttonPos - padding * 2; i++) {
                         builder.append(textToRender.charAt(i));
                     }
 
@@ -61,20 +60,20 @@ public class PresetsButton extends ControlsListWidget.CategoryEntry {
         } catch (IndexOutOfBoundsException ignored) {
         }
 
-        context.drawText(textRenderer, textToRender, x, getContentY() + getContentHeight() / 2 - 9 / 2, Colors.GRAY, true);
+        context.text(textRenderer, textToRender, x, getContentY() + getContentHeight() / 2 - 9 / 2, CommonColors.GRAY, true);
 
         presetSettings.setPosition(buttonPos, getContentY());
-        presetSettings.render(context, mouseX, mouseY, deltaTicks);
+        presetSettings.extractRenderState(context, mouseX, mouseY, deltaTicks);
     }
 
 
     @Override
-    public List<? extends Element> children() {
+    public List<? extends GuiEventListener> children() {
         return List.of(presetSettings);
     }
 
     @Override
-    public List<? extends Selectable> selectableChildren() {
+    public List<? extends NarratableEntry> narratables() {
         return List.of(presetSettings);
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetsListWidget.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetsListWidget.java
@@ -2,22 +2,22 @@ package net.sn0wix_.notEnoughKeybinds.gui.screen.presets;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.Click;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
-import net.minecraft.text.Text;
-import net.minecraft.util.Colors;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.CommonColors;
 import net.sn0wix_.notEnoughKeybinds.keybinds.presets.PresetLoader;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 import org.jetbrains.annotations.Nullable;
 
-public class PresetsListWidget extends AlwaysSelectedEntryListWidget<PresetsListWidget.PresetEntry> {
+public class PresetsListWidget extends ObjectSelectionList<PresetsListWidget.PresetEntry> {
     public final PresetsSettingScreen parent;
 
-    public PresetsListWidget(PresetsSettingScreen parent, MinecraftClient client, int width, int height, int y, int itemHeight) {
+    public PresetsListWidget(PresetsSettingScreen parent, Minecraft client, int width, int height, int y, int itemHeight) {
         super(client, width, height, y, itemHeight);
         this.parent = parent;
         initEntries();
@@ -25,7 +25,7 @@ public class PresetsListWidget extends AlwaysSelectedEntryListWidget<PresetsList
 
     public void initEntries() {
         clearEntries();
-        PresetLoader.getPresets().forEach(keybindPreset -> addEntry(new PresetEntry(keybindPreset, client.textRenderer)));
+        PresetLoader.getPresets().forEach(keybindPreset -> addEntry(new PresetEntry(keybindPreset, minecraft.font)));
     }
 
     @Override
@@ -35,20 +35,20 @@ public class PresetsListWidget extends AlwaysSelectedEntryListWidget<PresetsList
     }
 
     @Environment(EnvType.CLIENT)
-    public class PresetEntry extends AlwaysSelectedEntryListWidget.Entry<PresetEntry> implements AutoCloseable {
+    public class PresetEntry extends ObjectSelectionList.Entry<PresetEntry> implements AutoCloseable {
         public PresetLoader.KeybindPreset preset;
-        public TextRenderer textRenderer;
+        public Font textRenderer;
 
-        public PresetEntry(PresetLoader.KeybindPreset preset, TextRenderer textRenderer) {
+        public PresetEntry(PresetLoader.KeybindPreset preset, Font textRenderer) {
             this.preset = preset;
             this.textRenderer = textRenderer;
         }
 
         @Override
-        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
-            context.drawText(textRenderer, TextUtils.trimText(preset.getName(), textRenderer, getContentWidth() - 6), getContentX() + 3, getContentY() + 1, Colors.WHITE, false);
-            context.drawText(textRenderer, TextUtils.trimText(preset.getDescription(), textRenderer, getContentWidth()), getContentX() + 3, getContentY() + 9 + 3, Colors.LIGHT_GRAY, false);
-            context.drawText(textRenderer, TextUtils.trimText(preset.getFileName(), textRenderer, getContentWidth()), getContentX() + 3, getContentY() + 9 + 9 + 3, Formatting.DARK_GRAY.getColorValue(), false);
+        public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            context.text(textRenderer, TextUtils.trimText(preset.getName(), textRenderer, getContentWidth() - 6), getContentX() + 3, getContentY() + 1, CommonColors.WHITE, false);
+            context.text(textRenderer, TextUtils.trimText(preset.getDescription(), textRenderer, getContentWidth()), getContentX() + 3, getContentY() + 9 + 3, CommonColors.LIGHT_GRAY, false);
+            context.text(textRenderer, TextUtils.trimText(preset.getFileName(), textRenderer, getContentWidth()), getContentX() + 3, getContentY() + 9 + 9 + 3, ChatFormatting.DARK_GRAY.getColor(), false);
 
         }
 
@@ -57,14 +57,14 @@ public class PresetsListWidget extends AlwaysSelectedEntryListWidget<PresetsList
         }
 
         @Override
-        public boolean mouseClicked(Click click, boolean doubled) {
+        public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
             PresetsListWidget.this.setSelected(this);
             return true;
         }
 
         @Override
-        public Text getNarration() {
-            return Text.literal(preset.getName());
+        public Component getNarration() {
+            return Component.literal(preset.getName());
         }
 
         public void close() {

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetsSettingScreen.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/gui/screen/presets/PresetsSettingScreen.java
@@ -1,15 +1,14 @@
 package net.sn0wix_.notEnoughKeybinds.gui.screen.presets;
 
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.option.ControlsListWidget;
-import net.minecraft.client.gui.screen.option.KeybindsScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.client.gui.widget.TextWidget;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.screen.ScreenTexts;
-import net.minecraft.text.Text;
-import net.minecraft.util.Colors;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsList;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsScreen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.gui.ParentScreenBlConsumer;
 import net.sn0wix_.notEnoughKeybinds.gui.SettingsScreen;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.BasicLayoutWidget;
@@ -19,20 +18,20 @@ import net.sn0wix_.notEnoughKeybinds.util.Utils;
 import org.lwjgl.glfw.GLFW;
 
 public class PresetsSettingScreen extends SettingsScreen {
-    public ButtonWidget deleteButton;
-    public ButtonWidget loadButton;
-    public ButtonWidget editButton;
-    public ButtonWidget writeButton;
-    public ButtonWidget createNewButton;
-    public ButtonWidget backButton;
-    public TextWidget currentPresetText;
+    public Button deleteButton;
+    public Button loadButton;
+    public Button editButton;
+    public Button writeButton;
+    public Button createNewButton;
+    public Button backButton;
+    public StringWidget currentPresetText;
 
     private PresetsListWidget presetsList;
 
     public PresetsSettingScreen(Screen parent) {
-        super(parent, Text.translatable(TextUtils.getSettingsTranslationKey("presets")),
-                BasicLayoutWidget.DEFAULT_HEADER_FOOTER_HEIGHT + 8,
-                BasicLayoutWidget.DEFAULT_HEADER_FOOTER_HEIGHT + 25);
+        super(parent, Component.translatable(TextUtils.getSettingsTranslationKey("presets")),
+                BasicLayoutWidget.DEFAULT_HEADER_AND_FOOTER_HEIGHT + 8,
+                BasicLayoutWidget.DEFAULT_HEADER_AND_FOOTER_HEIGHT + 25);
     }
 
     @Override
@@ -43,106 +42,105 @@ public class PresetsSettingScreen extends SettingsScreen {
 
     @Override
     public void initHeader() {
-        DirectionalLayoutWidget header = DirectionalLayoutWidget.vertical().spacing(7);
-        TextWidget headerText = new TextWidget(title, textRenderer);
+        LinearLayout header = LinearLayout.vertical().spacing(7);
+        StringWidget headerText = new StringWidget(title, font);
         headerText.setWidth(200);
 
-        currentPresetText = new TextWidget(Text.of(PresetLoader.getCurrentPresetName()), textRenderer);
-        currentPresetText.setTextColor(Colors.GRAY);
+        currentPresetText = new StringWidget(Component.nullToEmpty(PresetLoader.getCurrentPresetName()), font);
         currentPresetText.setWidth(200);
 
-        header.add(headerText);
-        header.add(currentPresetText);
-        threePartsLayout.addHeader(header);
+        header.addChild(headerText);
+        header.addChild(currentPresetText);
+        threePartsLayout.addToHeader(header);
     }
 
     @Override
     protected void initBody() {
-        threePartsLayout.addBody(presetsList);
+        threePartsLayout.addToContents(presetsList);
     }
 
     @Override
     public void initFooter() {
-        DirectionalLayoutWidget footerBody = DirectionalLayoutWidget.horizontal().spacing(5);
-        DirectionalLayoutWidget left = DirectionalLayoutWidget.vertical().spacing(5);
-        DirectionalLayoutWidget right = DirectionalLayoutWidget.vertical().spacing(5);
+        LinearLayout footerBody = LinearLayout.horizontal().spacing(5);
+        LinearLayout left = LinearLayout.vertical().spacing(5);
+        LinearLayout right = LinearLayout.vertical().spacing(5);
 
-        left.add(loadButton);
-        right.add(createNewButton);
+        left.addChild(loadButton);
+        right.addChild(createNewButton);
 
-        DirectionalLayoutWidget leftBottom = DirectionalLayoutWidget.horizontal().spacing(5);
-        DirectionalLayoutWidget rightBottom = DirectionalLayoutWidget.horizontal().spacing(5);
-        leftBottom.add(editButton);
-        leftBottom.add(deleteButton);
+        LinearLayout leftBottom = LinearLayout.horizontal().spacing(5);
+        LinearLayout rightBottom = LinearLayout.horizontal().spacing(5);
+        leftBottom.addChild(editButton);
+        leftBottom.addChild(deleteButton);
 
-        rightBottom.add(writeButton);
-        rightBottom.add(backButton);
+        rightBottom.addChild(writeButton);
+        rightBottom.addChild(backButton);
 
-        left.add(leftBottom);
-        right.add(rightBottom);
+        left.addChild(leftBottom);
+        right.addChild(rightBottom);
 
-        footerBody.add(left);
-        footerBody.add(right);
-        threePartsLayout.addFooter(footerBody);
+        footerBody.addChild(left);
+        footerBody.addChild(right);
+        threePartsLayout.addToFooter(footerBody);
     }
 
     @Override
-    public void refreshWidgetPositions() {
-        super.refreshWidgetPositions();
+    public void repositionElements() {
+        super.repositionElements();
 
         if (this.presetsList != null) {
-            this.presetsList.position(this.width, this.threePartsLayout);
+            this.presetsList.updateSize(this.width, this.threePartsLayout);
         }
     }
 
     public void initButtons() {
-        this.presetsList = new PresetsListWidget(this, this.client, this.width, threePartsLayout.getContentHeight(), threePartsLayout.getHeaderHeight(), 36);
+        this.presetsList = new PresetsListWidget(this, this.minecraft, this.width, threePartsLayout.getContentHeight(), threePartsLayout.getHeaderHeight(), 36);
 
-        this.loadButton = ButtonWidget.builder(TextUtils.getText("load_preset"), button -> {
-            if (presetsList.getSelectedOrNull() != null) {
-                PresetLoader.loadPreset(presetsList.getSelectedOrNull().getPreset());
+        this.loadButton = Button.builder(TextUtils.getText("load_preset"), button -> {
+            if (presetsList.getSelected() != null) {
+                PresetLoader.loadPreset(presetsList.getSelected().getPreset());
             }
 
             updateScreen();
         }).size(150, 20).build();
 
-        this.createNewButton = ButtonWidget.builder(TextUtils.getText("create_preset"), button -> client.setScreen(new PresetEditScreen(this, new PresetLoader.KeybindPreset(), true))).dimensions(this.width / 2 + 4, this.height - 52, 150, 20).tooltip(TextUtils.getTooltip("create_preset")).build();
-        this.editButton = ButtonWidget.builder(TextUtils.getText("edit"), button -> {
-            if (presetsList.getSelectedOrNull() != null) {
-                client.setScreen(new PresetEditScreen(this, presetsList.getSelectedOrNull().getPreset(), false));
+        this.createNewButton = Button.builder(TextUtils.getText("create_preset"), button -> minecraft.setScreen(new PresetEditScreen(this, new PresetLoader.KeybindPreset(), true))).bounds(this.width / 2 + 4, this.height - 52, 150, 20).tooltip(TextUtils.getTooltip("create_preset")).build();
+        this.editButton = Button.builder(TextUtils.getText("edit"), button -> {
+            if (presetsList.getSelected() != null) {
+                minecraft.setScreen(new PresetEditScreen(this, presetsList.getSelected().getPreset(), false));
             }
         }).size(72, 20).build();
 
-        this.deleteButton = ButtonWidget.builder(TextUtils.getText("delete"), button -> client.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(this, client1 -> {
-            if (presetsList.getSelectedOrNull() != null) {
-                PresetLoader.KeybindPreset p = presetsList.getSelectedOrNull().getPreset();
+        this.deleteButton = Button.builder(TextUtils.getText("delete"), button -> minecraft.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(this, client1 -> {
+            if (presetsList.getSelected() != null) {
+                PresetLoader.KeybindPreset p = presetsList.getSelected().getPreset();
                 PresetLoader.deletePreset(p);
                 Utils.showToastNotification(TextUtils.getText("preset.delete.toast", p.getName()));
-                this.clearAndInit();
+                this.rebuildWidgets();
             }
-        }, true), TextUtils.getText("preset.delete.confirm", presetsList.getSelectedOrNull().getPreset().getName())))).size(72, 20).build();
+        }, true), TextUtils.getText("preset.delete.confirm", presetsList.getSelected().getPreset().getName())))).size(72, 20).build();
 
-        this.writeButton = ButtonWidget.builder(TextUtils.getText("write"), button -> {
-            client.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(this, client1 -> {
-                if (presetsList.getSelectedOrNull() != null) {
-                    PresetLoader.writePreset(presetsList.getSelectedOrNull().getPreset(), Utils.bindingsToList(false));
-                    Utils.showToastNotification(TextUtils.getText("preset.write", presetsList.getSelectedOrNull().getPreset().getName()));
+        this.writeButton = Button.builder(TextUtils.getText("write"), button -> {
+            minecraft.setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(this, client1 -> {
+                if (presetsList.getSelected() != null) {
+                    PresetLoader.writePreset(presetsList.getSelected().getPreset(), Utils.bindingsToList(false));
+                    Utils.showToastNotification(TextUtils.getText("preset.write", presetsList.getSelected().getPreset().getName()));
                 }
-            }, true), TextUtils.getText("preset.write.confirm", presetsList.getSelectedOrNull().getPreset().getName())));
+            }, true), TextUtils.getText("preset.write.confirm", presetsList.getSelected().getPreset().getName())));
             updateScreen();
         }).size(72, 20).tooltip(TextUtils.getTooltip("write_preset")).build();
 
-        this.backButton = ButtonWidget.builder(ScreenTexts.BACK, button -> {
+        this.backButton = Button.builder(CommonComponents.GUI_BACK, button -> {
             //update the parent gui
-            if (parent instanceof KeybindsScreen keybindsScreen) {
+            if (parent instanceof KeyBindsScreen keybindsScreen) {
                 keybindsScreen.children().forEach(child -> {
-                    if (child instanceof ControlsListWidget widget) {
-                        widget.update();
+                    if (child instanceof KeyBindsList widget) {
+                        widget.resetMappingAndUpdateButtons();
                     }
                 });
             }
 
-            client.setScreen(parent);
+            minecraft.setScreen(parent);
         }).size(72, 20).build();
 
         updateScreen();
@@ -150,41 +148,41 @@ public class PresetsSettingScreen extends SettingsScreen {
 
     //overwriting protected to public
     @Override
-    public void clearAndInit() {
-        super.clearAndInit();
+    public void rebuildWidgets() {
+        super.rebuildWidgets();
     }
 
     public void updateScreen() {
-        writeButton.active = presetsList.getSelectedOrNull() != null;
-        deleteButton.active = presetsList.getSelectedOrNull() != null;
-        editButton.active = presetsList.getSelectedOrNull() != null;
-        loadButton.active = presetsList.getSelectedOrNull() != null;
+        writeButton.active = presetsList.getSelected() != null;
+        deleteButton.active = presetsList.getSelected() != null;
+        editButton.active = presetsList.getSelected() != null;
+        loadButton.active = presetsList.getSelected() != null;
 
         if (currentPresetText != null) {
-            currentPresetText.setMessage(Text.of(PresetLoader.getCurrentPresetName()));
+            currentPresetText.setMessage(Component.nullToEmpty(PresetLoader.getCurrentPresetName()));
         }
     }
 
     @Override
-    public boolean keyPressed(KeyInput input) {
-        if (input.getKeycode() == GLFW.GLFW_KEY_F5) {
+    public boolean keyPressed(KeyEvent input) {
+        if (input.input() == GLFW.GLFW_KEY_F5) {
             PresetLoader.reload(true);
-            this.clearAndInit();
+            this.rebuildWidgets();
             return true;
         }
 
         if (getFocused() != null && getFocused() == presetsList) {
-            if (input.getKeycode() == GLFW.GLFW_KEY_DELETE && presetsList.getSelectedOrNull() != null) {
+            if (input.input() == GLFW.GLFW_KEY_DELETE && presetsList.getSelected() != null) {
                 deleteButton.onPress(input);
                 return true;
-            } else if (input.getKeycode() == GLFW.GLFW_KEY_ENTER && presetsList.getSelectedOrNull() != null) {
+            } else if (input.input() == GLFW.GLFW_KEY_ENTER && presetsList.getSelected() != null) {
                 loadButton.onPress(input);
                 return true;
-            } else if (input.getKeycode() == GLFW.GLFW_KEY_KP_ADD) {
+            } else if (input.input() == GLFW.GLFW_KEY_KP_ADD) {
                 createNewButton.onPress(input);
                 return true;
             }
-        } else if (input.getKeycode() == GLFW.GLFW_KEY_ENTER && getFocused() instanceof ButtonWidget buttonWidget) {
+        } else if (input.input() == GLFW.GLFW_KEY_ENTER && getFocused() instanceof Button buttonWidget) {
             buttonWidget.onPress(input);
         }
 

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/BuildingKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/BuildingKeys.java
@@ -1,14 +1,14 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.item.ItemStack;
-import net.minecraft.text.Text;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
-import net.minecraft.util.math.BlockPos;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.KeybindCategory;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.NotEKKeyBinding;
@@ -17,35 +17,35 @@ import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 public class BuildingKeys extends NotEKKeyBindings {
     private static int itemUseCooldown = 0;
     public static final String BUILDING_CATEGORY_KEY = "key.category." + NotEnoughKeybinds.MOD_ID + ".building";
-    public static final KeyBinding.Category BUILDING_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(BUILDING_CATEGORY_KEY));
+    public static final KeyMapping.Category BUILDING_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(BUILDING_CATEGORY_KEY));
 
 
 
     public static final NotEKKeyBinding FAST_BUILDING = registerModKeyBinding(new NotEKKeyBinding("fast_building", BUILDING_CATEGORY, new NotEKKeyBinding.KeybindingTicker() {
         @Override
-        public void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding) {
+        public void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding) {
         }
 
         @Override
-        public void onTick(MinecraftClient client, NotEKKeyBinding keyBinding) {
-            for (Hand hand : Hand.values()) {
-                if (isInGame(client) && (keyBinding.isPressed() || keyBinding.wasPressed())) {
-                    ItemStack itemStack = client.player.getStackInHand(hand);
+        public void onTick(Minecraft client, NotEKKeyBinding keyBinding) {
+            for (InteractionHand hand : InteractionHand.values()) {
+                if (isInGame(client) && (keyBinding.isDown() || keyBinding.consumeClick())) {
+                    ItemStack itemStack = client.player.getItemInHand(hand);
 
-                    if (client.crosshairTarget.getType().equals(HitResult.Type.BLOCK)) {
-                        BlockHitResult blockHitResult = (BlockHitResult) client.crosshairTarget;
+                    if (client.hitResult.getType().equals(HitResult.Type.BLOCK)) {
+                        BlockHitResult blockHitResult = (BlockHitResult) client.hitResult;
                         int i = itemStack.getCount();
-                        ActionResult actionResult2 = client.interactionManager.interactBlock(client.player, hand, blockHitResult);
-                        if (actionResult2.isAccepted()) {
-                            if (actionResult2 instanceof ActionResult.Success success && success.swingSource() == ActionResult.SwingSource.CLIENT) {
-                                client.player.swingHand(hand);
-                                if (!itemStack.isEmpty() && (itemStack.getCount() != i || client.interactionManager.getCurrentGameMode().isCreative())) {
-                                    client.gameRenderer.firstPersonRenderer.resetEquipProgress(hand);
+                        InteractionResult actionResult2 = client.gameMode.useItemOn(client.player, hand, blockHitResult);
+                        if (actionResult2.consumesAction()) {
+                            if (actionResult2 instanceof InteractionResult.Success success && success.swingSource() == InteractionResult.SwingSource.CLIENT) {
+                                client.player.swing(hand);
+                                if (!itemStack.isEmpty() && (itemStack.getCount() != i || client.gameMode.getPlayerMode().isCreative())) {
+                                    client.gameRenderer.itemInHandRenderer.itemUsed(hand);
                                 }
                             }
                             return;
                         }
-                        if (actionResult2 == ActionResult.FAIL) {
+                        if (actionResult2 == InteractionResult.FAIL) {
                             return;
                         }
                     }
@@ -54,26 +54,26 @@ public class BuildingKeys extends NotEKKeyBindings {
         }
     }) {
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("fast_building", true);
         }
     });
 
     public static final NotEKKeyBinding FAST_BLOCK_BREAKING = registerModKeyBinding(new NotEKKeyBinding("fast_block_breaking", BUILDING_CATEGORY, new NotEKKeyBinding.KeybindingTicker() {
         @Override
-        public void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding) {
+        public void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding) {
         }
 
         @Override
-        public void onTick(MinecraftClient client, NotEKKeyBinding keyBinding) {
-            for (Hand hand : Hand.values()) {
-                if (isInGame(client) && (keyBinding.isPressed() || keyBinding.wasPressed())) {
-                    if (client.crosshairTarget.getType().equals(HitResult.Type.BLOCK)) {
-                        BlockHitResult blockHitResult = (BlockHitResult) client.crosshairTarget;
+        public void onTick(Minecraft client, NotEKKeyBinding keyBinding) {
+            for (InteractionHand hand : InteractionHand.values()) {
+                if (isInGame(client) && (keyBinding.isDown() || keyBinding.consumeClick())) {
+                    if (client.hitResult.getType().equals(HitResult.Type.BLOCK)) {
+                        BlockHitResult blockHitResult = (BlockHitResult) client.hitResult;
                         BlockPos blockPos = blockHitResult.getBlockPos();
-                        if (!client.world.getBlockState(blockPos).isAir()) {
-                            client.interactionManager.attackBlock(blockPos, blockHitResult.getSide());
-                            client.player.swingHand(hand);
+                        if (!client.level.getBlockState(blockPos).isAir()) {
+                            client.gameMode.startDestroyBlock(blockPos, blockHitResult.getDirection());
+                            client.player.swing(hand);
                             break;
                         }
                     }
@@ -82,31 +82,31 @@ public class BuildingKeys extends NotEKKeyBindings {
         }
     }) {
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("fast_block_breaking", true);
         }
     });
 
     public static final NotEKKeyBinding ALWAYS_PLACE_ITEM = registerModKeyBinding(new NotEKKeyBinding("always_place_item", BUILDING_CATEGORY, (client, keyBinding) -> {
         if (itemUseCooldown == 0) {
-            for (Hand hand : Hand.values()) {
-                ItemStack itemStack = client.player.getStackInHand(hand);
+            for (InteractionHand hand : InteractionHand.values()) {
+                ItemStack itemStack = client.player.getItemInHand(hand);
 
-                if (!client.crosshairTarget.getType().equals(HitResult.Type.ENTITY)) {
-                    BlockHitResult blockHitResult = (BlockHitResult) client.crosshairTarget;
+                if (!client.hitResult.getType().equals(HitResult.Type.ENTITY)) {
+                    BlockHitResult blockHitResult = (BlockHitResult) client.hitResult;
                     int i = itemStack.getCount();
-                    ActionResult actionResult2 = client.interactionManager.interactBlock(client.player, hand, blockHitResult);
-                    if (actionResult2.isAccepted()) {
+                    InteractionResult actionResult2 = client.gameMode.useItemOn(client.player, hand, blockHitResult);
+                    if (actionResult2.consumesAction()) {
                         itemUseCooldown = 4;
-                        if (actionResult2 instanceof ActionResult.Success success && success.swingSource() == ActionResult.SwingSource.CLIENT) {
-                            client.player.swingHand(hand);
-                            if (!itemStack.isEmpty() && (itemStack.getCount() != i || client.interactionManager.getCurrentGameMode().isCreative())) {
-                                client.gameRenderer.firstPersonRenderer.resetEquipProgress(hand);
+                        if (actionResult2 instanceof InteractionResult.Success success && success.swingSource() == InteractionResult.SwingSource.CLIENT) {
+                            client.player.swing(hand);
+                            if (!itemStack.isEmpty() && (itemStack.getCount() != i || client.gameMode.getPlayerMode().isCreative())) {
+                                client.gameRenderer.itemInHandRenderer.itemUsed(hand);
                             }
                         }
                         return;
                     }
-                    if (actionResult2 == ActionResult.FAIL) {
+                    if (actionResult2 == InteractionResult.FAIL) {
                         return;
                     }
                 }
@@ -114,12 +114,12 @@ public class BuildingKeys extends NotEKKeyBindings {
         }
     }){
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("always_place_item", true);
         }
 
         @Override
-        public void tick(MinecraftClient client) {
+        public void tick(Minecraft client) {
             if (itemUseCooldown > 0) {
                 itemUseCooldown--;
             }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/ChatKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/ChatKeys.java
@@ -1,7 +1,7 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.Screen;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.keySettings.ChatKeyScreen;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.ChatKeyBinding;
@@ -16,7 +16,7 @@ import java.util.Random;
 public class ChatKeys extends NotEKKeyBindings {
     public static final String CHAT_KEYS_CATEGORY_KEY = "key.category." + NotEnoughKeybinds.MOD_ID + ".chat_keys";
     public static final ChatKeysCategory CHAT_KEYS_MOD_CATEGORY = new ChatKeysCategory(CHAT_KEYS_CATEGORY_KEY, 1);
-    public static final KeyBinding.Category CHAT_KEYS_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(CHAT_KEYS_CATEGORY_KEY));
+    public static final KeyMapping.Category CHAT_KEYS_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(CHAT_KEYS_CATEGORY_KEY));
 
 
 
@@ -67,7 +67,7 @@ public class ChatKeys extends NotEKKeyBindings {
         }
 
         public boolean addKeyIf(ChatKeyBinding keyBinding) {
-            boolean bl = chatKeys.removeIf((binding) -> binding.getId().equals(keyBinding.getId()));
+            boolean bl = chatKeys.removeIf((binding) -> binding.getName().equals(keyBinding.getName()));
             chatKeys.add(keyBinding);
             NotEnoughKeybinds.CHAT_KEYS_CONFIG.addKeyIf(keyBinding);
             update();
@@ -77,12 +77,12 @@ public class ChatKeys extends NotEKKeyBindings {
 
         public void update() {
             NotEKKeyBindings.updateCategory(this);
-            KeyBinding.updateKeysByCode();
+            KeyMapping.resetMapping();
         }
 
         public void initializeKeys() {
             chatKeys.addAll(NotEnoughKeybinds.CHAT_KEYS_CONFIG.loadKeys());
-            KeyBinding.updateKeysByCode();
+            KeyMapping.resetMapping();
         }
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/F3ShortcutsKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/F3ShortcutsKeys.java
@@ -1,6 +1,6 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.KeyMapping;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.F3ShortcutKeybinding;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.KeybindCategory;
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class F3ShortcutsKeys extends NotEKKeyBindings {
     public static final String F3_SHORTCUTS_CATEGORY_KEY = "key.category." + NotEnoughKeybinds.MOD_ID + ".f3_shortcuts";
-    public static final KeyBinding.Category F3_SHORTCUTS_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(F3_SHORTCUTS_CATEGORY_KEY));
+    public static final KeyMapping.Category F3_SHORTCUTS_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(F3_SHORTCUTS_CATEGORY_KEY));
 
     public static final NotEKKeyBinding TOGGLE_HITBOXES = registerModKeyBinding(new F3ShortcutKeybinding("toggle_hitboxes", 66));
     public static final NotEKKeyBinding TOGGLE_CHUNK_GRID = registerModKeyBinding(new F3ShortcutKeybinding("toggle_chunk_grid", 71));

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/InventoryKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/InventoryKeys.java
@@ -1,12 +1,12 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.item.Items;
-import net.minecraft.text.Text;
-import net.minecraft.util.Hand;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.Items;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.keySettings.SwapTotemShieldSettings;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.EquipElytraBinding;
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class InventoryKeys extends NotEKKeyBindings {
     public static final String INVENTORY_CATEGORY_KEY = "key.category." + NotEnoughKeybinds.MOD_ID + ".inventory";
-    public static final KeyBinding.Category INVENTORY_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(INVENTORY_CATEGORY_KEY));
+    public static final KeyMapping.Category INVENTORY_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(INVENTORY_CATEGORY_KEY));
 
 
     public static int lastSwitchedTotemShieldSlot = -1;
@@ -32,9 +32,9 @@ public class InventoryKeys extends NotEKKeyBindings {
         boolean elytra = false;
         boolean swapFirstOrSecond = false;
 
-        if (client.player.getInventory().getStack(EquipmentSlot.CHEST.getOffsetEntitySlotId(PlayerInventory.MAIN_SIZE)).isOf(Items.ELYTRA)) {
+        if (client.player.getInventory().getItem(EquipmentSlot.CHEST.getIndex(Inventory.INVENTORY_SIZE)).is(Items.ELYTRA)) {
             itemSlot.set(InventoryUtils.getSlotWithChestplate(client));
-        } else if (!client.player.getInventory().getStack(EquipmentSlot.CHEST.getOffsetEntitySlotId(PlayerInventory.MAIN_SIZE)).isEmpty()) {
+        } else if (!client.player.getInventory().getItem(EquipmentSlot.CHEST.getIndex(Inventory.INVENTORY_SIZE)).isEmpty()) {
             itemSlot.set(InventoryUtils.getSlotWithElytra(client));
             elytra = true;
         }
@@ -84,18 +84,18 @@ public class InventoryKeys extends NotEKKeyBindings {
                         }
                         case 2 -> {
                             //current slotIn
-                            InventoryUtils.switchInvHandSlot(client, Hand.MAIN_HAND, itemSlot.get());
+                            InventoryUtils.switchInvHandSlot(client, InteractionHand.MAIN_HAND, itemSlot.get());
                             swapBackSlot = client.player.getInventory().getSelectedSlot();
                         }
                         case 3 -> {
                             //offhand
-                            InventoryUtils.switchInvHandSlot(client, Hand.OFF_HAND, itemSlot.get());
+                            InventoryUtils.switchInvHandSlot(client, InteractionHand.OFF_HAND, itemSlot.get());
                             swapBackSlot = 40;
                         }
                     }
                     if (NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapBackOldItem && swapBackSlot != -1 && NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode != 4) {
                         //write swap back
-                        ElytraController.setSwapBackItem(itemSlot.get(), swapBackSlot, client.player.getInventory().getStack(itemSlot.get()).getItem());
+                        ElytraController.setSwapBackItem(itemSlot.get(), swapBackSlot, client.player.getInventory().getItem(itemSlot.get()).getItem());
                     }
                 }
 
@@ -106,8 +106,8 @@ public class InventoryKeys extends NotEKKeyBindings {
                         return;
                     }
 
-                    if (NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.useRocket && client.player.getStackInHand(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode == 3 ? Hand.OFF_HAND : Hand.MAIN_HAND).isOf(Items.FIREWORK_ROCKET))
-                        InventoryUtils.interactItem(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode == 3 ? Hand.OFF_HAND : Hand.MAIN_HAND, client);
+                    if (NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.useRocket && client.player.getItemInHand(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode == 3 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND).is(Items.FIREWORK_ROCKET))
+                        InventoryUtils.interactItem(NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.equipMode == 3 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND, client);
                 };
 
                 if (NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.enterFlightMode) {
@@ -119,7 +119,7 @@ public class InventoryKeys extends NotEKKeyBindings {
             } else if (NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapBackOldItem && !swapFirstOrSecond) {
                 //execute swap back
 
-                if (ElytraController.hasSwapBack() && ElytraController.shouldSwapBack(client.player.getInventory().getStack(ElytraController.getSwapBackItemSlot()))) {
+                if (ElytraController.hasSwapBack() && ElytraController.shouldSwapBack(client.player.getInventory().getItem(ElytraController.getSwapBackItemSlot()))) {
                     InventoryUtils.switchInvHotbarSlot(client, ElytraController.getSwapBackRocketSlot(), ElytraController.getSwapBackItemSlot());
                     ElytraController.clearSwapBackData();
                 }
@@ -129,17 +129,17 @@ public class InventoryKeys extends NotEKKeyBindings {
 
     public static final NotEKKeyBinding SWITCH_TOTEM_SHIELD = registerModKeyBinding(new NotEKKeyBinding("switch_totem_shield", INVENTORY_CATEGORY, (client, keyBinding) -> {
         assert client.player != null;
-        Hand hand = client.player.getStackInHand(Hand.OFF_HAND).isEmpty() ? Hand.MAIN_HAND : Hand.OFF_HAND;
+        InteractionHand hand = client.player.getItemInHand(InteractionHand.OFF_HAND).isEmpty() ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND;
 
         if (lastSwitchedTotemShieldSlot > -1)
-            lastSwitchedTotemShieldSlot = client.player.getInventory().getStack(lastSwitchedTotemShieldSlot).isOf(client.player.getStackInHand(hand).getItem()) ?
-                    -1 : client.player.getInventory().getStack(lastSwitchedTotemShieldSlot).isEmpty() ? -1 : lastSwitchedTotemShieldSlot;
+            lastSwitchedTotemShieldSlot = client.player.getInventory().getItem(lastSwitchedTotemShieldSlot).is(client.player.getItemInHand(hand).getItem()) ?
+                    -1 : client.player.getInventory().getItem(lastSwitchedTotemShieldSlot).isEmpty() ? -1 : lastSwitchedTotemShieldSlot;
 
         int slot = -1;
 
-        if (client.player.getStackInHand(hand).isOf(Items.SHIELD)) {
+        if (client.player.getItemInHand(hand).is(Items.SHIELD)) {
             slot = InventoryUtils.getTotemSwapSlot(client, lastSwitchedTotemShieldSlot);
-        } else if (client.player.getStackInHand(hand).isOf(Items.TOTEM_OF_UNDYING)) {
+        } else if (client.player.getItemInHand(hand).is(Items.TOTEM_OF_UNDYING)) {
             slot = InventoryUtils.getShieldSwapSlot(client);
         }
 
@@ -160,7 +160,7 @@ public class InventoryKeys extends NotEKKeyBindings {
                 }
 
                 if (slot > -1 && slot != 40) {
-                    InventoryUtils.switchInvHandSlot(client, Hand.OFF_HAND, slot);
+                    InventoryUtils.switchInvHandSlot(client, InteractionHand.OFF_HAND, slot);
                     break;
                 } else if (NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapSecond) {
                     string = NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.getOppositeSwap();
@@ -169,7 +169,7 @@ public class InventoryKeys extends NotEKKeyBindings {
         }
     }) {
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("switch_totem_shield", true);
         }
 
@@ -181,8 +181,8 @@ public class InventoryKeys extends NotEKKeyBindings {
 
 
     public static final NotEKKeyBinding THROW_ENDER_PEARL = registerModKeyBinding(new NotEKKeyBinding("throw_ender_pearl", INVENTORY_CATEGORY, (client, keyBinding) -> {
-        for (Hand hand : Hand.values()) {
-            if (client.player.getStackInHand(hand).isOf(Items.ENDER_PEARL)) {
+        for (InteractionHand hand : InteractionHand.values()) {
+            if (client.player.getItemInHand(hand).is(Items.ENDER_PEARL)) {
                 InventoryUtils.interactItem(hand, client);
                 return;
             }
@@ -195,15 +195,15 @@ public class InventoryKeys extends NotEKKeyBindings {
         }
     }) {
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("throw_ender_pearl", true);
         }
     });
 
 
     public static final NotEKKeyBinding THROW_WIND_CHARGE = registerModKeyBinding(new NotEKKeyBinding("throw_wind_charge", INVENTORY_CATEGORY, (client, keyBinding) -> {
-        for (Hand hand : Hand.values()) {
-            if (client.player.getStackInHand(hand).isOf(Items.WIND_CHARGE)) {
+        for (InteractionHand hand : InteractionHand.values()) {
+            if (client.player.getItemInHand(hand).is(Items.WIND_CHARGE)) {
                 InventoryUtils.interactItem(hand, client);
                 return;
             }
@@ -215,7 +215,7 @@ public class InventoryKeys extends NotEKKeyBindings {
         }
     }) {
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("throw_wind_charge", true);
         }
     });

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/MiscKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/MiscKeys.java
@@ -1,18 +1,18 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.gui.screen.GameMenuScreen;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.world.ClientWorld;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.PauseScreen;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.KeybindCategory;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.NotEKKeyBinding;
 
 public class MiscKeys extends NotEKKeyBindings{
-    public static final String MISC_CATEGORY_KEY = NotEnoughKeybinds.getIdentifier("misc").toTranslationKey("key.category");
-    public static final KeyBinding.Category MISC_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(MISC_CATEGORY_KEY));
+    public static final String MISC_CATEGORY_KEY = NotEnoughKeybinds.getIdentifier("misc").toLanguageKey("key.category");
+    public static final KeyMapping.Category MISC_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(MISC_CATEGORY_KEY));
 
     public static final NotEKKeyBinding DISCONNECT = registerModKeyBinding(new NotEKKeyBinding("disconnect", MISC_CATEGORY, (client, keyBinding) -> {
-            client.getAbuseReportContext().tryShowDraftScreen(client, new GameMenuScreen(true), () -> client.disconnect(ClientWorld.QUITTING_MULTIPLAYER_TEXT), true);
+            client.getReportingContext().draftReportHandled(client, new PauseScreen(true), () -> client.disconnectFromWorld(ClientLevel.DEFAULT_QUIT_MESSAGE), true);
     }));
 
     @Override

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/NotEKKeyBindings.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/NotEKKeyBindings.java
@@ -1,13 +1,12 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.util.InputUtil;
+import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
+import net.minecraft.client.KeyMapping;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.KeybindCategory;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.NotEKKeyBinding;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.INotEKKeybinding;
-
+import com.mojang.blaze3d.platform.InputConstants;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -19,7 +18,7 @@ public abstract class NotEKKeyBindings {
 
 
     //why this isn't a thing in vanilla
-    public static final KeyBinding TOGGLE_HIDE_HUD = registerKeyBinding(new KeyBinding(KEY_BINDING_PREFIX + "toggle_hide_hud", InputUtil.GLFW_KEY_F1, KeyBinding.Category.MISC));
+    public static final KeyMapping TOGGLE_HIDE_HUD = registerKeyMapping(new KeyMapping(KEY_BINDING_PREFIX + "toggle_hide_hud", InputConstants.KEY_F1, KeyMapping.Category.MISC));
 
 
     public static void registerModKeybinds() {
@@ -63,11 +62,11 @@ public abstract class NotEKKeyBindings {
 
 
     public static NotEKKeyBinding registerModKeyBinding(NotEKKeyBinding keyBinding) {
-        return (NotEKKeyBinding) KeyBindingHelper.registerKeyBinding(keyBinding);
+        return (NotEKKeyBinding) KeyMappingHelper.registerKeyMapping(keyBinding);
     }
 
-    public static KeyBinding registerKeyBinding(KeyBinding keyBinding) {
-        return KeyBindingHelper.registerKeyBinding(keyBinding);
+    public static KeyMapping registerKeyMapping(KeyMapping keyBinding) {
+        return KeyMappingHelper.registerKeyMapping(keyBinding);
     }
 
     //Helper methods

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/PresetKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/PresetKeys.java
@@ -1,8 +1,8 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.text.Text;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.INotEKKeybinding;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.KeybindCategory;
@@ -14,20 +14,20 @@ import java.util.NoSuchElementException;
 
 public class PresetKeys extends NotEKKeyBindings {
     public static final String PRESET_CATEGORY_KEY = "key.category." + NotEnoughKeybinds.MOD_ID + ".presets";
-    public static final KeyBinding.Category PRESET_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(PRESET_CATEGORY_KEY));
+    public static final KeyMapping.Category PRESET_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(PRESET_CATEGORY_KEY));
 
     public static final NotEKKeyBinding NEXT_PRESET = registerModKeyBinding(new NotEKKeyBinding("next_preset", PRESET_CATEGORY, new PresetBinding(true)));
     public static final NotEKKeyBinding PREVIOUS_PRESET = registerModKeyBinding(new NotEKKeyBinding("previous_preset", PRESET_CATEGORY, new PresetBinding(false)));
 
     public static final NotEKKeyBinding NEXT_PRESET_GLOBAL = registerModKeyBinding(new NotEKKeyBinding("next_preset_global", PRESET_CATEGORY, new PresetBinding(true)) {
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("key_global", true);
         }
     });
     public static final NotEKKeyBinding PREVIOUS_PRESET_GLOBAL = registerModKeyBinding(new NotEKKeyBinding("previous_preset_global", PRESET_CATEGORY, new PresetBinding(false)) {
         @Override
-        public Text getTooltip() {
+        public Component getTooltip() {
             return TextUtils.getText("key_global", true);
         }
     });
@@ -45,7 +45,7 @@ public class PresetKeys extends NotEKKeyBindings {
         }
 
         @Override
-        public void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding) {
+        public void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding) {
             try {
                 if (PresetLoader.getCurrentPreset() == null) {
                     try {

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/SkinLayersKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/SkinLayersKeys.java
@@ -1,8 +1,8 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.entity.player.PlayerModelPart;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.player.PlayerModelPart;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.KeybindCategory;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.NotEKKeyBinding;
@@ -10,7 +10,7 @@ import net.sn0wix_.notEnoughKeybinds.keybinds.custom.INotEKKeybinding;
 
 public class SkinLayersKeys extends NotEKKeyBindings {
     public static final String SKIN_LAYERS_CATEGORY_KEY = "key.category." + NotEnoughKeybinds.MOD_ID + ".skin_layers";
-    public static final KeyBinding.Category SKIN_LAYERS_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(SKIN_LAYERS_CATEGORY_KEY));
+    public static final KeyMapping.Category SKIN_LAYERS_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(SKIN_LAYERS_CATEGORY_KEY));
 
 
     public static final NotEKKeyBinding TOGGLE_SKIN_LAYER_CAPE = registerModKeyBinding(new NotEKKeyBinding("toggle_skin_layer_cape", SKIN_LAYERS_CATEGORY, new SkinLayerKeybinding(PlayerModelPart.CAPE)));
@@ -41,13 +41,13 @@ public class SkinLayersKeys extends NotEKKeyBindings {
         }
 
         @Override
-        public void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding) {
+        public void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding) {
             enableModelPart(client, modelPart);
         }
     }
 
-    public static void enableModelPart(MinecraftClient client, PlayerModelPart playerModelPart) {
-        client.options.setPlayerModelPart(playerModelPart, !client.options.isPlayerModelPartEnabled(playerModelPart));
-        client.options.write();
+    public static void enableModelPart(Minecraft client, PlayerModelPart playerModelPart) {
+        client.options.setModelPart(playerModelPart, !client.options.isModelPartEnabled(playerModelPart));
+        client.options.save();
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/SoundKeys.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/SoundKeys.java
@@ -1,9 +1,9 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.text.Text;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.sounds.SoundSource;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.INotEKKeybinding;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.KeybindCategory;
@@ -12,27 +12,27 @@ import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 
 public class SoundKeys extends NotEKKeyBindings {
     public static final String SOUND_KEYS_CATEGORY_KEY = "key.category." + NotEnoughKeybinds.MOD_ID + ".sound";
-    public static final KeyBinding.Category SOUND_KEYS_CATEGORY = KeyBinding.Category.create(NotEnoughKeybinds.getIdentifier(SOUND_KEYS_CATEGORY_KEY));
+    public static final KeyMapping.Category SOUND_KEYS_CATEGORY = KeyMapping.Category.register(NotEnoughKeybinds.getIdentifier(SOUND_KEYS_CATEGORY_KEY));
 
 
     public static final NotEKKeyBinding TOGGLE_SUBTITLES = registerModKeyBinding(new NotEKKeyBinding("toggle_subtitles", SOUND_KEYS_CATEGORY, (client, keyBinding) -> {
-        client.options.getShowSubtitles().setValue(!client.options.getShowSubtitles().getValue());
+        client.options.showSubtitles().set(!client.options.showSubtitles().get());
     }));
 
-    public static final NotEKKeyBinding INCREASE_MASTER_VOLUME = registerModKeyBinding(new NotEKKeyBinding("increase_master_volume", SOUND_KEYS_CATEGORY, new VolumeKeybindingTicker(SoundCategory.MASTER, 0.1f)));
-    public static final NotEKKeyBinding DECREASE_MASTER_VOLUME = registerModKeyBinding(new NotEKKeyBinding("decrease_master_volume", SOUND_KEYS_CATEGORY, new VolumeKeybindingTicker(SoundCategory.MASTER, -0.1f)));
+    public static final NotEKKeyBinding INCREASE_MASTER_VOLUME = registerModKeyBinding(new NotEKKeyBinding("increase_master_volume", SOUND_KEYS_CATEGORY, new VolumeKeybindingTicker(SoundSource.MASTER, 0.1f)));
+    public static final NotEKKeyBinding DECREASE_MASTER_VOLUME = registerModKeyBinding(new NotEKKeyBinding("decrease_master_volume", SOUND_KEYS_CATEGORY, new VolumeKeybindingTicker(SoundSource.MASTER, -0.1f)));
 
 
     @Override
     public KeybindCategory getModCategory() {
-        INotEKKeybinding[] bindings = new INotEKKeybinding[SoundCategory.values().length + 3];
+        INotEKKeybinding[] bindings = new INotEKKeybinding[SoundSource.values().length + 3];
         bindings[0] = TOGGLE_SUBTITLES;
         bindings[1] = INCREASE_MASTER_VOLUME;
         bindings[2] = DECREASE_MASTER_VOLUME;
 
-        int i = bindings.length - SoundCategory.values().length;
+        int i = bindings.length - SoundSource.values().length;
 
-        for (SoundCategory category : SoundCategory.values()) {
+        for (SoundSource category : SoundSource.values()) {
             bindings[i] = registerModKeyBinding(new SoundKeybinding("soundCategory." + category.getName(), SOUND_KEYS_CATEGORY, category));
             i++;
         }
@@ -42,17 +42,17 @@ public class SoundKeys extends NotEKKeyBindings {
 
 
     public static class SoundKeybinding extends NotEKKeyBinding {
-        public SoundCategory category;
+        public SoundSource category;
 
-        public SoundKeybinding(String translationKey, Category category, SoundCategory soundCategory) {
+        public SoundKeybinding(String translationKey, Category category, SoundSource soundCategory) {
             super(translationKey, category, new ToggleCategoryBindingTicker(soundCategory));
             this.category = soundCategory;
         }
 
         @Override
-        public Text getSettingsDisplayName() {
-            return TextUtils.getCombinedTranslation(Text.translatable(TextUtils.getTranslationKey("toggle")),
-                    Text.translatable("soundCategory." + category.getName()));
+        public Component getSettingsDisplayName() {
+            return TextUtils.getCombinedTranslation(Component.translatable(TextUtils.getTranslationKey("toggle")),
+                    Component.translatable("soundCategory." + category.getName()));
         }
     }
 
@@ -60,34 +60,34 @@ public class SoundKeys extends NotEKKeyBindings {
     public static class ToggleCategoryBindingTicker implements INotEKKeybinding.KeybindingTicker {
         private double previousVolume = 1;
 
-        private final SoundCategory category;
+        private final SoundSource category;
 
-        public ToggleCategoryBindingTicker(SoundCategory category) {
+        public ToggleCategoryBindingTicker(SoundSource category) {
             this.category = category;
         }
 
         @Override
-        public void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding) {
-            if (client.options.getSoundVolumeOption(category).getValue() > 0) {
-                previousVolume = client.options.getSoundVolumeOption(category).getValue() > 0 ? client.options.getSoundVolumeOption(category).getValue() : 1;
-                client.options.getSoundVolumeOption(category).setValue(0.0);
+        public void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding) {
+            if (client.options.getSoundSourceOptionInstance(category).get() > 0) {
+                previousVolume = client.options.getSoundSourceOptionInstance(category).get() > 0 ? client.options.getSoundSourceOptionInstance(category).get() : 1;
+                client.options.getSoundSourceOptionInstance(category).set(0.0);
             } else {
-                client.options.getSoundVolumeOption(category).setValue(previousVolume);
+                client.options.getSoundSourceOptionInstance(category).set(previousVolume);
             }
         }
     }
 
-    public record VolumeKeybindingTicker(SoundCategory category, float scaling) implements INotEKKeybinding.KeybindingTicker {
+    public record VolumeKeybindingTicker(SoundSource category, float scaling) implements INotEKKeybinding.KeybindingTicker {
         @Override
-        public void onTick(MinecraftClient client, NotEKKeyBinding keyBinding) {
-            while (keyBinding.wasPressed()) {
+        public void onTick(Minecraft client, NotEKKeyBinding keyBinding) {
+            while (keyBinding.consumeClick()) {
                 onWasPressed(client, keyBinding);
             }
         }
 
         @Override
-        public void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding) {
-            double value = client.options.getSoundVolumeOption(category).getValue();
+        public void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding) {
+            double value = client.options.getSoundSourceOptionInstance(category).get();
             value += scaling;
 
             if (value < 0) {
@@ -96,7 +96,7 @@ public class SoundKeys extends NotEKKeyBindings {
                 value = 1;
             }
 
-            client.options.getSoundVolumeOption(category).setValue(value);
+            client.options.getSoundSourceOptionInstance(category).set(value);
         }
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/ChatKeyBinding.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/ChatKeyBinding.java
@@ -1,11 +1,11 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.custom;
 
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
-import net.minecraft.util.StringHelper;
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.StringUtil;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.keySettings.ChatKeyScreen;
 import net.sn0wix_.notEnoughKeybinds.keybinds.ChatKeys;
@@ -22,12 +22,12 @@ public class ChatKeyBinding extends NotEKKeyBinding {
         this.displayName = displayName;
     }
 
-    public ChatKeyBinding(String translationKey, String displayName, String chatMessage, InputUtil.Key boundKey) {
+    public ChatKeyBinding(String translationKey, String displayName, String chatMessage, InputConstants.Key boundKey) {
         //this keybinding was loaded from the config file with the prefix, so we don't add the prefix for the second time
         super(translationKey, ChatKeys.CHAT_KEYS_CATEGORY, new ChatKeysTicker(), false);
         this.chatMessage = chatMessage;
         this.displayName = displayName;
-        setBoundKey(boundKey);
+        setKey(boundKey);
     }
 
     public String getChatMessage() {
@@ -43,14 +43,14 @@ public class ChatKeyBinding extends NotEKKeyBinding {
     }
 
     @Override
-    public Text getSettingsDisplayName() {
-        return Text.literal(displayName);
+    public Component getSettingsDisplayName() {
+        return Component.literal(displayName);
     }
 
     @Override
-    public void setAndSaveKeyBinding(InputUtil.Key key) {
+    public void setAndSaveKeyBinding(InputConstants.Key key) {
         super.setAndSaveKeyBinding(key);
-        NotEnoughKeybinds.CHAT_KEYS_CONFIG.updateKey(this.getId(), key);
+        NotEnoughKeybinds.CHAT_KEYS_CONFIG.updateKey(this.getName(), key);
     }
 
     @Override
@@ -59,29 +59,29 @@ public class ChatKeyBinding extends NotEKKeyBinding {
     }
 
     @Override
-    public Text getTooltip() {
-        return Text.translatable(TextUtils.getTranslationKey(chatMessage.startsWith("/") ? "executes_command" : "sends_message", true), chatMessage);
+    public Component getTooltip() {
+        return Component.translatable(TextUtils.getTranslationKey(chatMessage.startsWith("/") ? "executes_command" : "sends_message", true), chatMessage);
     }
 
     public static class ChatKeysTicker implements KeybindingTicker {
         @Override
-        public void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding) {
+        public void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding) {
             if (keyBinding instanceof ChatKeyBinding chatKeyBinding) {
-                sendMessage(chatKeyBinding.getChatMessage(), client.inGameHud.getChatHud() != null, client);
+                sendMessage(chatKeyBinding.getChatMessage(), client.gui.getChat() != null, client);
             }
         }
 
-        public static void sendMessage(String chatText, boolean addToHistory, MinecraftClient client) {
+        public static void sendMessage(String chatText, boolean addToHistory, Minecraft client) {
             chatText = normalize(chatText);
             if (!chatText.isEmpty()) {
                 if (addToHistory) {
-                    client.inGameHud.getChatHud().addToMessageHistory(chatText);
+                    client.gui.getChat().addRecentChat(chatText);
                 }
                 assert client.player != null;
                 if (chatText.startsWith("/")) {
-                    client.player.networkHandler.sendChatCommand(chatText.substring(1));
+                    client.player.connection.sendCommand(chatText.substring(1));
                 } else {
-                    client.player.networkHandler.sendChatMessage(chatText);
+                    client.player.connection.sendChat(chatText);
                 }
             }
         }
@@ -90,7 +90,7 @@ public class ChatKeyBinding extends NotEKKeyBinding {
          * {@return the {@code message} normalized by trimming it and then normalizing spaces}
          */
         public static String normalize(String chatText) {
-            return StringHelper.truncateChat(StringUtils.normalizeSpace(chatText.trim()));
+            return StringUtil.trimChatMessage(StringUtils.normalizeSpace(chatText.trim()));
         }
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/EquipElytraBinding.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/EquipElytraBinding.java
@@ -1,10 +1,10 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.custom;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.config.EquipElytraConfig;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.keySettings.EquipElytraSettings;
@@ -31,7 +31,7 @@ public class EquipElytraBinding extends NotEKKeyBinding {
             return "auto-detect";
         }
 
-        return super.getBoundKeyTranslationKey();
+        return super.saveString();
     }
 
     @Override
@@ -40,21 +40,21 @@ public class EquipElytraBinding extends NotEKKeyBinding {
     }
 
     @Override
-    public Text getTooltip() {
+    public Component getTooltip() {
         return TextUtils.getText("switch_elytra_chestplate", true);
     }
 
     @Override
-    public void setAndSaveKeyBinding(InputUtil.Key key) {
+    public void setAndSaveKeyBinding(InputConstants.Key key) {
         if (key.equals(getDefaultKey()) && NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect) {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect = false;
             EquipElytraConfig.saveConfig();
             return;
         }
 
-        if (MinecraftClient.getInstance().options.jumpKey.matchesKey(new KeyInput(key.getCode(), 0, 0))) { //        if (MinecraftClient.getInstance().options.jumpKey.matchesKey(key.getCode(), 0)) {
+        if (Minecraft.getInstance().options.keyJump.matches(new KeyEvent(key.getValue(), 0, 0))) { //        if (MinecraftClient.getInstance().options.jumpKey.matchesKey(key.getCode(), 0)) {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect = true;
-            super.setAndSaveKeyBinding(InputUtil.UNKNOWN_KEY);
+            super.setAndSaveKeyBinding(InputConstants.UNKNOWN);
         } else {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect = false;
             super.setAndSaveKeyBinding(key);
@@ -63,7 +63,7 @@ public class EquipElytraBinding extends NotEKKeyBinding {
         EquipElytraConfig.saveConfig();
     }
     @Override
-    public Text getBoundKeyLocalizedText() {
-        return NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect ? TextUtils.getText("elytra_auto_detect") : super.getBoundKeyLocalizedText();
+    public Component getTranslatedKeyMessage() {
+        return NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect ? TextUtils.getText("elytra_auto_detect") : super.getTranslatedKeyMessage();
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/F3DebugKeybinding.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/F3DebugKeybinding.java
@@ -1,34 +1,33 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.custom;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.resource.language.I18n;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.F3DebugKeys;
 import net.sn0wix_.notEnoughKeybinds.keybinds.NotEKKeyBindings;
 import org.jetbrains.annotations.NotNull;
-
+import com.mojang.blaze3d.platform.InputConstants;
 import java.util.Objects;
 
 public class F3DebugKeybinding implements INotEKKeybinding, Comparable<F3DebugKeybinding> {
     public final String translationKey;
     public final String category;
-    public InputUtil.Key boundKey;
-    public final InputUtil.Key defaultKey;
+    public InputConstants.Key boundKey;
+    public final InputConstants.Key defaultKey;
 
     public F3DebugKeybinding(String translationKey, int code) {
         this.translationKey = NotEKKeyBindings.KEY_BINDING_PREFIX + translationKey;
-        this.boundKey = InputUtil.fromKeyCode(new KeyInput(code, 0, 0));
+        this.boundKey = InputConstants.getKey(new KeyEvent(code, 0, 0));
         this.defaultKey = this.boundKey;
         this.category = F3DebugKeys.F3_DEBUG_KEYS_CATEGORY_KEY;
     }
 
     @Override
-    public Text getBoundKeyLocalizedText() {
-        return Text.literal("F3 + " + boundKey.getLocalizedText().getString());
+    public Component getBoundKeyLocalizedText() {
+        return Component.literal("F3 + " + boundKey.getDisplayName().getString());
     }
 
     @Override
@@ -38,46 +37,46 @@ public class F3DebugKeybinding implements INotEKKeybinding, Comparable<F3DebugKe
 
     @Override
     public String getBoundKeyTranslationKey() {
-        return this.boundKey.getTranslationKey();
+        return this.boundKey.getName();
     }
 
     @Override
-    public void tick(MinecraftClient client) {
+    public void tick(Minecraft client) {
     }
 
     @Override
-    public boolean matchesKey(KeyInput key) {
-        if (key.key() == InputUtil.UNKNOWN_KEY.getCode()) {
-            return this.boundKey.getCategory() == InputUtil.Type.SCANCODE && this.boundKey.getCode() == key.scancode();
+    public boolean matchesKey(KeyEvent key) {
+        if (key.key() == InputConstants.UNKNOWN.getValue()) {
+            return this.boundKey.getType() == InputConstants.Type.SCANCODE && this.boundKey.getValue() == key.scancode();
         }
-        return this.boundKey.getCategory() == InputUtil.Type.KEYSYM && this.boundKey.getCode() == key.key();
+        return this.boundKey.getType() == InputConstants.Type.KEYSYM && this.boundKey.getValue() == key.key();
     }
 
     @Override
-    public void setAndSaveKeyBinding(InputUtil.Key key) {
+    public void setAndSaveKeyBinding(InputConstants.Key key) {
         setBoundKey(key);
     }
 
     @Override
-    public void setBoundKey(InputUtil.Key boundKey) {
+    public void setBoundKey(InputConstants.Key boundKey) {
         this.boundKey = boundKey;
         if (NotEnoughKeybinds.DEBUG_KEYS_CONFIG != null) {
-            NotEnoughKeybinds.DEBUG_KEYS_CONFIG.saveBoundKey(getId(), boundKey.getTranslationKey());
+            NotEnoughKeybinds.DEBUG_KEYS_CONFIG.saveBoundKey(getId(), boundKey.getName());
         }
     }
 
     @Override
-    public KeyBinding getBinding() {
+    public KeyMapping getBinding() {
         return null;
     }
 
     @Override
     public boolean isUnbound() {
-        return boundKey.equals(InputUtil.UNKNOWN_KEY);
+        return boundKey.equals(InputConstants.UNKNOWN);
     }
 
     @Override
-    public InputUtil.Key getDefaultKey() {
+    public InputConstants.Key getDefaultKey() {
         return defaultKey;
     }
 
@@ -87,14 +86,14 @@ public class F3DebugKeybinding implements INotEKKeybinding, Comparable<F3DebugKe
     }
 
     @Override
-    public KeyBinding.Category getCategory() {
+    public KeyMapping.Category getCategory() {
         return null;
     }
 
     @Override
     public int compareTo(@NotNull F3DebugKeybinding keyBinding) {
         if (Objects.equals(this.category, keyBinding.category)) {
-            return I18n.translate(this.translationKey).compareTo(I18n.translate(keyBinding.translationKey));
+            return I18n.get(this.translationKey).compareTo(I18n.get(keyBinding.translationKey));
         }
         return 0; //Integer.compare(KeyBinding.Category.CATEGORIES.indexOf(this.category), KeyBinding.Category.CATEGORIES.indexOf(keyBinding.category));
     }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/F3ShortcutKeybinding.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/F3ShortcutKeybinding.java
@@ -1,6 +1,6 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.custom;
 
-import net.minecraft.client.util.InputUtil;
+import com.mojang.blaze3d.platform.InputConstants;
 import net.sn0wix_.notEnoughKeybinds.keybinds.F3ShortcutsKeys;
 
 public class F3ShortcutKeybinding extends NotEKKeyBinding {
@@ -11,17 +11,17 @@ public class F3ShortcutKeybinding extends NotEKKeyBinding {
         this.codeToEmulate = codeToEmulate;
     }
 
-    public F3ShortcutKeybinding(String translationKey, InputUtil.Type type, int code, int codeToEmulate) {
+    public F3ShortcutKeybinding(String translationKey, InputConstants.Type type, int code, int codeToEmulate) {
         super(translationKey, type, code, F3ShortcutsKeys.F3_SHORTCUTS_CATEGORY, null);
         this.codeToEmulate = codeToEmulate;
     }
 
     public F3ShortcutKeybinding(String translationKey,  int codeToEmulate) {
-        this(translationKey, InputUtil.UNKNOWN_KEY.getCode(), codeToEmulate);
+        this(translationKey, InputConstants.UNKNOWN.getValue(), codeToEmulate);
     }
 
-    public F3ShortcutKeybinding(String translationKey, InputUtil.Type type, int codeToEmulate) {
-        this(translationKey, type, InputUtil.UNKNOWN_KEY.getCode(), codeToEmulate);
+    public F3ShortcutKeybinding(String translationKey, InputConstants.Type type, int codeToEmulate) {
+        this(translationKey, type, InputConstants.UNKNOWN.getValue(), codeToEmulate);
     }
 
 

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/INotEKKeybinding.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/INotEKKeybinding.java
@@ -1,31 +1,31 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.custom;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
 
 public interface INotEKKeybinding {
-    void setBoundKey(InputUtil.Key key);
+    void setBoundKey(InputConstants.Key key);
 
-    KeyBinding getBinding();
+    KeyMapping getBinding();
 
     boolean isUnbound();
 
-    InputUtil.Key getDefaultKey();
+    InputConstants.Key getDefaultKey();
 
     String getId();
 
-    KeyBinding.Category getCategory();
+    KeyMapping.Category getCategory();
 
-    Text getBoundKeyLocalizedText();
+    Component getBoundKeyLocalizedText();
 
     boolean isDefault();
 
-    default Text getTooltip() {
-        return Text.empty();
+    default Component getTooltip() {
+        return Component.empty();
     }
 
     default Screen getSettingsScreen(Screen parent) {
@@ -34,14 +34,14 @@ public interface INotEKKeybinding {
 
     String getBoundKeyTranslationKey();
 
-    void tick(MinecraftClient client);
+    void tick(Minecraft client);
 
-    boolean matchesKey(KeyInput key);
+    boolean matchesKey(KeyEvent key);
 
-    void setAndSaveKeyBinding(InputUtil.Key key);
+    void setAndSaveKeyBinding(InputConstants.Key key);
 
-    default Text getSettingsDisplayName() {
-        return Text.translatable(getId());
+    default Component getSettingsDisplayName() {
+        return Component.translatable(getId());
     }
 
     default String getBoundKeyTranslation() {
@@ -54,18 +54,18 @@ public interface INotEKKeybinding {
         /**
          * Executes if the keybind is pressed while a world is loaded
          */
-        void onWasPressed(MinecraftClient client, NotEKKeyBinding keyBinding);
+        void onWasPressed(Minecraft client, NotEKKeyBinding keyBinding);
 
         /**
          * Executes every tick
          */
-        default void onTick(MinecraftClient client, NotEKKeyBinding keyBinding) {
-            while (keyBinding.wasPressed() && isInGame(client)) {
+        default void onTick(Minecraft client, NotEKKeyBinding keyBinding) {
+            while (keyBinding.consumeClick() && isInGame(client)) {
                 onWasPressed(client, keyBinding);
             }
         }
 
-        default boolean isInGame(MinecraftClient client) {
+        default boolean isInGame(Minecraft client) {
             return client.player != null;
         }
     }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/KeybindCategory.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/KeybindCategory.java
@@ -1,9 +1,9 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.custom;
 
-import net.minecraft.client.gui.screen.Screen;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import net.minecraft.client.gui.screens.Screen;
 
 public class KeybindCategory {
     private final String TRANSLATION_KEY;

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/NotEKKeyBinding.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/custom/NotEKKeyBinding.java
@@ -1,13 +1,13 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.custom;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.keybinds.NotEKKeyBindings;
 
-public class NotEKKeyBinding extends KeyBinding implements INotEKKeybinding {
+public class NotEKKeyBinding extends KeyMapping implements INotEKKeybinding {
     private final KeybindingTicker onWasPressed;
 
 
@@ -16,7 +16,7 @@ public class NotEKKeyBinding extends KeyBinding implements INotEKKeybinding {
         this.onWasPressed = onTick;
     }
 
-    public NotEKKeyBinding(String translationKey, InputUtil.Type type, int code, Category category, KeybindingTicker onTick, boolean useCustomTranslation) {
+    public NotEKKeyBinding(String translationKey, InputConstants.Type type, int code, Category category, KeybindingTicker onTick, boolean useCustomTranslation) {
         super(useCustomTranslation ? NotEKKeyBindings.KEY_BINDING_PREFIX + translationKey : translationKey, type, code, category);
         this.onWasPressed = onTick;
     }
@@ -25,36 +25,41 @@ public class NotEKKeyBinding extends KeyBinding implements INotEKKeybinding {
         this(translationKey, code, category, onTick, true);
     }
 
-    public NotEKKeyBinding(String translationKey, InputUtil.Type type, int code, Category category, KeybindingTicker onTick) {
+    public NotEKKeyBinding(String translationKey, InputConstants.Type type, int code, Category category, KeybindingTicker onTick) {
         this(translationKey, type, code, category, onTick, true);
     }
 
     public NotEKKeyBinding(String translationKey, Category category, KeybindingTicker onTick) {
-        this(translationKey, InputUtil.UNKNOWN_KEY.getCode(), category, onTick, true);
+        this(translationKey, InputConstants.UNKNOWN.getValue(), category, onTick, true);
     }
 
     public NotEKKeyBinding(String translationKey, Category category, KeybindingTicker onTick, boolean useCustomTranslation) {
-        this(translationKey, InputUtil.UNKNOWN_KEY.getCode(), category, onTick, useCustomTranslation);
+        this(translationKey, InputConstants.UNKNOWN.getValue(), category, onTick, useCustomTranslation);
     }
 
 
     @Override
-    public KeyBinding getBinding() {
+    public KeyMapping getBinding() {
         return this;
     }
 
     @Override
-    public void setAndSaveKeyBinding(InputUtil.Key key) {
-        this.setBoundKey(key);
+    public void setAndSaveKeyBinding(InputConstants.Key key) {
+        this.setKey(key);
     }
 
-    public void tick(MinecraftClient client) {
+    @Override
+    public void setBoundKey(InputConstants.Key key) {
+        this.setKey(key);
+    }
+
+    public void tick(Minecraft client) {
         if (onWasPressed != null) {
             onWasPressed.onTick(client, this);
         }
     }
 
-    public void onWasPressed(MinecraftClient client) {
+    public void onWasPressed(Minecraft client) {
         if (onWasPressed != null) {
             onWasPressed.onWasPressed(client, this);
         }
@@ -62,8 +67,8 @@ public class NotEKKeyBinding extends KeyBinding implements INotEKKeybinding {
 
     //Idk why this has to be there, but it doesn't work without it
     @Override
-    public void setBoundKey(InputUtil.Key boundKey) {
-        super.setBoundKey(boundKey);
+    public void setKey(InputConstants.Key boundKey) {
+        super.setKey(boundKey);
     }
 
     @Override
@@ -72,13 +77,18 @@ public class NotEKKeyBinding extends KeyBinding implements INotEKKeybinding {
     }
 
     @Override
-    public InputUtil.Key getDefaultKey() {
+    public InputConstants.Key getDefaultKey() {
         return super.getDefaultKey();
     }
 
     @Override
+    public String getName() {
+        return super.getName(); //?
+    }
+
+    @Override
     public String getId() {
-        return super.getId(); //?
+        return this.getName();
     }
 
     @Override
@@ -87,8 +97,13 @@ public class NotEKKeyBinding extends KeyBinding implements INotEKKeybinding {
     }
 
     @Override
-    public Text getBoundKeyLocalizedText() {
-        return super.getBoundKeyLocalizedText();
+    public Component getTranslatedKeyMessage() {
+        return super.getTranslatedKeyMessage();
+    }
+
+    @Override
+    public Component getBoundKeyLocalizedText() {
+        return this.getTranslatedKeyMessage();
     }
 
     @Override
@@ -97,12 +112,17 @@ public class NotEKKeyBinding extends KeyBinding implements INotEKKeybinding {
     }
 
     @Override
-    public String getBoundKeyTranslationKey() {
-        return super.getBoundKeyTranslationKey();
+    public String saveString() {
+        return super.saveString();
     }
 
     @Override
-    public boolean matchesKey(KeyInput key) {
-        return super.matchesKey(key);
+    public String getBoundKeyTranslationKey() {
+        return this.saveString();
+    }
+
+    @Override
+    public boolean matchesKey(KeyEvent key) {
+        return super.matches(key);
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/presets/PresetLoader.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/keybinds/presets/PresetLoader.java
@@ -1,10 +1,9 @@
 package net.sn0wix_.notEnoughKeybinds.keybinds.presets;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.option.GameOptions;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.config.EquipElytraConfig;
 import net.sn0wix_.notEnoughKeybinds.config.NotEKSettings;
@@ -15,7 +14,7 @@ import net.sn0wix_.notEnoughKeybinds.keybinds.PresetKeys;
 import net.sn0wix_.notEnoughKeybinds.keybinds.custom.INotEKKeybinding;
 import net.sn0wix_.notEnoughKeybinds.util.TextUtils;
 import net.sn0wix_.notEnoughKeybinds.util.Utils;
-
+import com.mojang.blaze3d.platform.InputConstants;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -105,11 +104,11 @@ public class PresetLoader {
             if (translation.isEmpty() || value.isEmpty()) {
                 NotEnoughKeybinds.LOGGER.error("Incorrect keybinding entry in preset" + preset.name + ": " + translation + ":" + value);
             } else {
-                GameOptions options = MinecraftClient.getInstance().options;
+                Options options = Minecraft.getInstance().options;
                 boolean found = false;
 
                 //Equip elytra autodetect
-                if (translation.equals(InventoryKeys.EQUIP_ELYTRA.getId())) {
+                if (translation.equals(InventoryKeys.EQUIP_ELYTRA.getName())) {
                     NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect = value.equals("auto-detect");
                     EquipElytraConfig.saveConfig();
                     if (value.equals("auto-detect")) {
@@ -118,13 +117,13 @@ public class PresetLoader {
                     }
                 }
 
-                for (int i = 0; i < options.allKeys.length; i++) {
-                    KeyBinding binding = options.allKeys[i];
+                for (int i = 0; i < options.keyMappings.length; i++) {
+                    KeyMapping binding = options.keyMappings[i];
 
-                    if (binding.getId().equals(translation) &&
-                            !binding.getId().equals(PresetKeys.NEXT_PRESET_GLOBAL.getId()) &&
-                            !binding.getId().equals(PresetKeys.PREVIOUS_PRESET_GLOBAL.getId())) {
-                        binding.setBoundKey(InputUtil.fromTranslationKey(value));
+                    if (binding.getName().equals(translation) &&
+                            !binding.getName().equals(PresetKeys.NEXT_PRESET_GLOBAL.getName()) &&
+                            !binding.getName().equals(PresetKeys.PREVIOUS_PRESET_GLOBAL.getName())) {
+                        binding.setKey(InputConstants.getKey(value));
                         found = true;
                         break;
                     }
@@ -137,7 +136,7 @@ public class PresetLoader {
                         Stream.of(ChatKeys.CHAT_KEYS_MOD_CATEGORY.getKeyBindings(), F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings()).toList().forEach(iNotEKKeybindings -> {
                             for (INotEKKeybinding keybinding : iNotEKKeybindings) {
                                 if (keybinding.getId().equals(translation)) {
-                                    keybinding.setBoundKey(InputUtil.fromTranslationKey(finalValue));
+                                    keybinding.setBoundKey(InputConstants.getKey(finalValue));
                                     break;
                                 }
                             }
@@ -147,12 +146,12 @@ public class PresetLoader {
             }
         });
 
-        KeyBinding.updateKeysByCode();
-        KeyBinding.unpressAll();
-        KeyBinding.updatePressedStates();
+        KeyMapping.resetMapping();
+        KeyMapping.releaseAll();
+        KeyMapping.setAll();
 
         setCurrentPreset(preset);
-        Utils.showToastNotification(Text.translatable(TextUtils.getTranslationKey("preset.load"), preset.getName()));
+        Utils.showToastNotification(Component.translatable(TextUtils.getTranslationKey("preset.load"), preset.getName()));
         NotEnoughKeybinds.LOGGER.info("Preset " + preset.getName() + " was loaded!");
     }
 

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ClientPlayerEntityMixin.java
@@ -1,11 +1,11 @@
 package net.sn0wix_.notEnoughKeybinds.mixin;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.effect.StatusEffects;
-import net.minecraft.item.Items;
-import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.Items;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.InventoryKeys;
 import net.sn0wix_.notEnoughKeybinds.util.ElytraController;
@@ -16,15 +16,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(ClientPlayerEntity.class)
+@Mixin(LocalPlayer.class)
 public abstract class ClientPlayerEntityMixin {
     //Auto elytra detection
-    @Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;checkGliding()Z", shift = At.Shift.AFTER))
+    @Inject(method = "aiStep", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;tryToStartFallFlying()Z", shift = At.Shift.AFTER))
     private void injectTickMovement(CallbackInfo ci) {
         if (NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect
-                && checkFallFlying(((ClientPlayerEntity) (Object) this))
-                && !((ClientPlayerEntity) (Object) this).getEquippedStack(EquipmentSlot.CHEST).isOf(Items.ELYTRA)
-                && InventoryUtils.getSlotWithItem(Items.ELYTRA, ((ClientPlayerEntity) (Object) this).getInventory()) > -1) {
+                && checkFallFlying(((LocalPlayer) (Object) this))
+                && !((LocalPlayer) (Object) this).getItemBySlot(EquipmentSlot.CHEST).is(Items.ELYTRA)
+                && InventoryUtils.getSlotWithItem(Items.ELYTRA, ((LocalPlayer) (Object) this).getInventory()) > -1) {
 
             String swapFirstBefore = NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapFirst;
             boolean swapSecondBefore = NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond;
@@ -35,7 +35,7 @@ public abstract class ClientPlayerEntityMixin {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond = false;
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.enterFlightMode = true;
 
-            InventoryKeys.EQUIP_ELYTRA.onWasPressed(MinecraftClient.getInstance());
+            InventoryKeys.EQUIP_ELYTRA.onWasPressed(Minecraft.getInstance());
 
             //setting back the old parameters
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapFirst = swapFirstBefore;
@@ -43,16 +43,16 @@ public abstract class ClientPlayerEntityMixin {
             NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.enterFlightMode = enterFlightBefore;
 
             ElytraController.nextTick(() -> {
-                ((ClientPlayerEntity) (Object) this).startGliding();
-                ((ClientPlayerEntity) (Object) this).networkHandler.sendPacket(new ClientCommandC2SPacket(((ClientPlayerEntity) (Object) this), ClientCommandC2SPacket.Mode.START_FALL_FLYING));
+                ((LocalPlayer) (Object) this).startFallFlying();
+                ((LocalPlayer) (Object) this).connection.send(new ServerboundPlayerCommandPacket(((LocalPlayer) (Object) this), ServerboundPlayerCommandPacket.Action.START_FALL_FLYING));
             });
         }
     }
 
 
     @Unique
-    public boolean checkFallFlying(ClientPlayerEntity clientPlayerEntity) {
+    public boolean checkFallFlying(LocalPlayer clientPlayerEntity) {
         //return clientPlayerEntity.checkGliding();
-        return !clientPlayerEntity.isTouchingWater() && !clientPlayerEntity.isGliding() && !clientPlayerEntity.getAbilities().flying && !clientPlayerEntity.isOnGround() && !clientPlayerEntity.hasVehicle() && !clientPlayerEntity.hasStatusEffect(StatusEffects.LEVITATION);
+        return !clientPlayerEntity.isInWater() && !clientPlayerEntity.isFallFlying() && !clientPlayerEntity.getAbilities().flying && !clientPlayerEntity.onGround() && !clientPlayerEntity.isPassenger() && !clientPlayerEntity.hasEffect(MobEffects.LEVITATION);
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ControlsListWidgetAccessor.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ControlsListWidgetAccessor.java
@@ -1,12 +1,12 @@
 package net.sn0wix_.notEnoughKeybinds.mixin;
 
-import net.minecraft.client.gui.screen.option.ControlsListWidget;
-import net.minecraft.client.gui.screen.option.KeybindsScreen;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsList;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(ControlsListWidget.class)
+@Mixin(KeyBindsList.class)
 public interface ControlsListWidgetAccessor {
-    @Accessor("parent")
-    KeybindsScreen getParent();
+    @Accessor("keyBindsScreen")
+    KeyBindsScreen getParent();
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/GameModeSelectionFixerMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/GameModeSelectionFixerMixin.java
@@ -1,7 +1,7 @@
 package net.sn0wix_.notEnoughKeybinds.mixin;
 
-import net.minecraft.client.gui.screen.GameModeSwitcherScreen;
-import net.minecraft.client.input.KeyInput;
+import net.minecraft.client.gui.screens.debug.GameModeSwitcherScreen;
+import net.minecraft.client.input.KeyEvent;
 import net.sn0wix_.notEnoughKeybinds.keybinds.F3DebugKeys;
 import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,11 +11,11 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 @Mixin(GameModeSwitcherScreen.class)
 public abstract class GameModeSelectionFixerMixin {
     @ModifyVariable(method = "keyPressed", at = @At("HEAD"), ordinal = 0, argsOnly = true)
-    public KeyInput modifyF4(KeyInput input) {
-        if (F3DebugKeys.GAMEMODES.boundKey.getCode() == input.key()) {
-            return new KeyInput(GLFW.GLFW_KEY_F4, input.scancode(), input.modifiers());
+    public KeyEvent modifyF4(KeyEvent input) {
+        if (F3DebugKeys.GAMEMODES.boundKey.getValue() == input.key()) {
+            return new KeyEvent(GLFW.GLFW_KEY_F4, input.scancode(), input.modifiers());
         } else if (input.key() == GLFW.GLFW_KEY_F4) {
-            return new KeyInput(F3DebugKeys.GAMEMODES.boundKey.getCode(), input.scancode(), input.modifiers());
+            return new KeyEvent(F3DebugKeys.GAMEMODES.boundKey.getValue(), input.scancode(), input.modifiers());
         }
 
         return input;

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/KeyboardInputMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/KeyboardInputMixin.java
@@ -1,8 +1,8 @@
 package net.sn0wix_.notEnoughKeybinds.mixin;
 
-import net.minecraft.client.input.Input;
-import net.minecraft.client.input.KeyboardInput;
-import net.minecraft.client.option.GameOptions;
+import net.minecraft.client.Options;
+import net.minecraft.client.player.ClientInput;
+import net.minecraft.client.player.KeyboardInput;
 import net.sn0wix_.notEnoughKeybinds.util.ElytraController;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,12 +15,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class KeyboardInputMixin {
     @Shadow
     @Final
-    private GameOptions settings;
+    private Options options;
 
-    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/input/KeyboardInput;getMovementMultiplier(ZZ)F", shift = At.Shift.BEFORE, ordinal = 0))
+    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/KeyboardInput;calculateImpulse(ZZ)F", shift = At.Shift.BEFORE, ordinal = 0))
     public void injectJumping(CallbackInfo ci) {
-        if (ElytraController.shouldStimulateJump() || this.settings.jumpKey.isPressed()) {
-            ((Input) (Object) this).jump();
+        if (ElytraController.shouldStimulateJump() || this.options.keyJump.isDown()) {
+            ((ClientInput) (Object) this).makeJump();
         }
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/KeyboardMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/KeyboardMixin.java
@@ -98,7 +98,7 @@ public abstract class KeyboardMixin {
         return code;
     }
 
-    @ModifyArg(method = "handleDebugKeys", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyboardHandler;showDebugChat(Lnet/minecraft/network/chat/Component;)V"))
+    @ModifyArg(method = "handleDebugKeys", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyboardHandler;showDebugChat(Lnet/minecraft/network/chat/Component;)V"), require = 0)
     public Component fixHelpMessage(Component message) {
         return Utils.correctF3DebugMessage(message);
     }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/KeyboardMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/KeyboardMixin.java
@@ -1,9 +1,9 @@
 package net.sn0wix_.notEnoughKeybinds.mixin;
 
-import net.minecraft.client.Keyboard;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.text.Text;
+import net.minecraft.client.KeyboardHandler;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.keybindsScreen.NotEKSettingsScreen;
 import net.sn0wix_.notEnoughKeybinds.keybinds.F3DebugKeys;
 import net.sn0wix_.notEnoughKeybinds.keybinds.NotEKKeyBindings;
@@ -23,40 +23,40 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-@Mixin(Keyboard.class)
+@Mixin(KeyboardHandler.class)
 public abstract class KeyboardMixin {
     @Shadow
     @Final
-    private MinecraftClient client;
+    private Minecraft minecraft;
 
     @Shadow
-    protected abstract boolean processF3(KeyInput keyInput);
+    protected abstract boolean handleDebugKeys(KeyEvent keyInput);
 
 
     //missing F1 keybind
-    @Inject(method = "onKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/DebugHud;shouldShowRenderingChart()Z", shift = At.Shift.BEFORE))
-    private void injectOnKey(long window, int action, KeyInput input, CallbackInfo ci) {
-        if (input.key() == GLFW.GLFW_KEY_F1 && !NotEKKeyBindings.TOGGLE_HIDE_HUD.matchesKey(new KeyInput(input.key(), GLFW.glfwGetKeyScancode(input.key()),0 ))) {
-            this.client.options.hudHidden = !this.client.options.hudHidden;
+    @Inject(method = "keyPress", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/DebugScreenOverlay;showProfilerChart()Z", shift = At.Shift.BEFORE))
+    private void injectOnKey(long window, int action, KeyEvent input, CallbackInfo ci) {
+        if (input.key() == GLFW.GLFW_KEY_F1 && !NotEKKeyBindings.TOGGLE_HIDE_HUD.matches(new KeyEvent(input.key(), GLFW.glfwGetKeyScancode(input.key()),0 ))) {
+            this.minecraft.options.hideGui = !this.minecraft.options.hideGui;
         }
-        if (input.key() != GLFW.GLFW_KEY_F1 && NotEKKeyBindings.TOGGLE_HIDE_HUD.matchesKey(new KeyInput(input.key(), GLFW.glfwGetKeyScancode(input.key()), 0))) {
-            this.client.options.hudHidden = !this.client.options.hudHidden;
+        if (input.key() != GLFW.GLFW_KEY_F1 && NotEKKeyBindings.TOGGLE_HIDE_HUD.matches(new KeyEvent(input.key(), GLFW.glfwGetKeyScancode(input.key()), 0))) {
+            this.minecraft.options.hideGui = !this.minecraft.options.hideGui;
         }
     }
 
     //f3 shortcuts
-    @Inject(method = "onKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/KeyBinding;setKeyPressed(Lnet/minecraft/client/util/InputUtil$Key;Z)V", ordinal = 1, shift = At.Shift.BEFORE))
-    private void injectShortcuts(long window, int action, KeyInput input, CallbackInfo ci) {
+    @Inject(method = "keyPress", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;set(Lcom/mojang/blaze3d/platform/InputConstants$Key;Z)V", ordinal = 1, shift = At.Shift.BEFORE))
+    private void injectShortcuts(long window, int action, KeyEvent input, CallbackInfo ci) {
         List<Integer> codes = Utils.checkF3Shortcuts(input);
 
-        if (client.player != null && !codes.isEmpty() && !(client.currentScreen instanceof NotEKSettingsScreen)) {
-            codes.forEach(scanCode -> this.processF3(new KeyInput(scanCode, input.scancode(), 0))); //Will only codes work?
+        if (minecraft.player != null && !codes.isEmpty() && !(minecraft.screen instanceof NotEKSettingsScreen)) {
+            codes.forEach(scanCode -> this.handleDebugKeys(new KeyEvent(scanCode, input.scancode(), 0))); //Will only codes work?
         }
     }
 
     //f3 debug keys
-    @ModifyArg(method = "onKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Keyboard;processF3(Lnet/minecraft/client/input/KeyInput;)Z"))
-    private KeyInput injectProcessF3(KeyInput input) {
+    @ModifyArg(method = "keyPress", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyboardHandler;handleDebugKeys(Lnet/minecraft/client/input/KeyEvent;)Z"))
+    private KeyEvent injectProcessF3(KeyEvent input) {
         int key;
 
         Iterator<INotEKKeybinding> iterator = Arrays.stream(F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings()).iterator();
@@ -66,20 +66,20 @@ public abstract class KeyboardMixin {
             INotEKKeybinding keyBinding = iterator.next();
 
             if (keyBinding.matchesKey(input)) {
-                pressedF3Keys.add(keyBinding.getDefaultKey().getCode());
+                pressedF3Keys.add(keyBinding.getDefaultKey().getValue());
             }
         }
 
-        KeyInput finalInput = new KeyInput(0, 0, 0);
+        KeyEvent finalInput = new KeyEvent(0, 0, 0);
 
         while (!pressedF3Keys.isEmpty()) {
             key = pressedF3Keys.getFirst();
             pressedF3Keys.removeFirst();
 
-            finalInput = new KeyInput(key, input.scancode(), 0);
+            finalInput = new KeyEvent(key, input.scancode(), 0);
 
             if (!pressedF3Keys.isEmpty()) {
-                this.processF3(finalInput);
+                this.handleDebugKeys(finalInput);
             }
 
             pressedF3Keys.trimToSize();
@@ -89,23 +89,23 @@ public abstract class KeyboardMixin {
     }
 
 
-    @ModifyArg(method = "onKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/InputUtil;isKeyPressed(Lnet/minecraft/client/util/Window;I)Z"), index = 1)
+    @ModifyArg(method = "keyPress", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/platform/InputConstants;isKeyDown(Lcom/mojang/blaze3d/platform/Window;I)Z"), index = 1)
     public int fixF3C(int code) {
         if (code == GLFW.GLFW_KEY_C) {
-            code = F3DebugKeys.COPY_LOCATION.boundKey.getCode();
+            code = F3DebugKeys.COPY_LOCATION.boundKey.getValue();
         }
 
         return code;
     }
 
-    @ModifyArg(method = "processF3", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Keyboard;sendMessage(Lnet/minecraft/text/Text;)V"))
-    public Text fixHelpMessage(Text message) {
+    @ModifyArg(method = "handleDebugKeys", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyboardHandler;showDebugChat(Lnet/minecraft/network/chat/Component;)V"))
+    public Component fixHelpMessage(Component message) {
         return Utils.correctF3DebugMessage(message);
     }
 
 
-    @ModifyArg(method = "debugLog(Lnet/minecraft/text/Text;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Keyboard;getDebugMessage(Lnet/minecraft/util/Formatting;Lnet/minecraft/text/Text;)Lnet/minecraft/text/Text;"), index = 1)
-    public Text fixF3CMessage(Text message) {
-        return message.getContent().toString().contains("debug.crash.message") ? Text.translatable("debug.crash.message", F3DebugKeys.COPY_LOCATION.boundKey.getLocalizedText()) : message;
+    @ModifyArg(method = "debugFeedbackComponent(Lnet/minecraft/network/chat/Component;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyboardHandler;decorateDebugComponent(Lnet/minecraft/ChatFormatting;Lnet/minecraft/network/chat/Component;)Lnet/minecraft/network/chat/Component;"), index = 1)
+    public Component fixF3CMessage(Component message) {
+        return message.getContents().toString().contains("debug.crash.message") ? Component.translatable("debug.crash.message", F3DebugKeys.COPY_LOCATION.boundKey.getDisplayName()) : message;
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ModSettingsButtonMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ModSettingsButtonMixin.java
@@ -1,10 +1,10 @@
 package net.sn0wix_.notEnoughKeybinds.mixin;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.option.ControlsListWidget;
-import net.minecraft.client.gui.screen.option.KeybindsScreen;
-import net.minecraft.client.gui.widget.ElementListWidget;
-import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.ContainerObjectSelectionList;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsList;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsScreen;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.keybindsScreen.ModKeybindsButton;
 import net.sn0wix_.notEnoughKeybinds.gui.screen.presets.PresetsButton;
 import net.sn0wix_.notEnoughKeybinds.util.Utils;
@@ -14,21 +14,21 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(ControlsListWidget.class)
-public abstract class ModSettingsButtonMixin extends ElementListWidget<ControlsListWidget.Entry> {
-    public ModSettingsButtonMixin(MinecraftClient minecraftClient, int i, int j, int k, int l) {
+@Mixin(KeyBindsList.class)
+public abstract class ModSettingsButtonMixin extends ContainerObjectSelectionList<KeyBindsList.Entry> {
+    public ModSettingsButtonMixin(Minecraft minecraftClient, int i, int j, int k, int l) {
         super(minecraftClient, i, j, k, l);
     }
 
     @ModifyArg(method = "<init>", at = @At(value = "INVOKE", target = "Lorg/apache/commons/lang3/ArrayUtils;clone([Ljava/lang/Object;)[Ljava/lang/Object;"), remap = false)
     private Object[] filterKeybinds(Object[] keyBindings) {
-        return Utils.filterModKeybindings((KeyBinding[]) keyBindings);
+        return Utils.filterModKeybindings((KeyMapping[]) keyBindings);
     }
 
     @Inject(method = "<init>", at = @At("TAIL"))
-    private void injectTail(KeybindsScreen parent, MinecraftClient client, CallbackInfo ci) {
-        this.addEntryToTop(new PresetsButton(((ControlsListWidget)(Object)this), client.textRenderer));
-        this.addEntryToTop(new ModKeybindsButton(((ControlsListWidget)(Object)this)));
-        this.setScrollY(0);
+    private void injectTail(KeyBindsScreen parent, Minecraft client, CallbackInfo ci) {
+        this.addEntryToTop(new PresetsButton(((KeyBindsList)(Object)this), client.font));
+        this.addEntryToTop(new ModKeybindsButton(((KeyBindsList)(Object)this)));
+        this.setScrollAmount(0);
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ResetAllKeybindsMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ResetAllKeybindsMixin.java
@@ -1,11 +1,11 @@
 package net.sn0wix_.notEnoughKeybinds.mixin;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.option.ControlsListWidget;
-import net.minecraft.client.gui.screen.option.KeybindsScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.text.Text;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsList;
+import net.minecraft.client.gui.screens.options.controls.KeyBindsScreen;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.gui.ParentScreenBlConsumer;
 import net.sn0wix_.notEnoughKeybinds.keybinds.ChatKeys;
 import net.sn0wix_.notEnoughKeybinds.keybinds.F3DebugKeys;
@@ -17,16 +17,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(KeybindsScreen.class)
+@Mixin(KeyBindsScreen.class)
 public abstract class ResetAllKeybindsMixin {
-    @Shadow private ControlsListWidget controlsList;
+    @Shadow private KeyBindsList keyBindsList;
 
     //confirmation dialog
     @Inject(method = "method_60342", at = @At("HEAD"), cancellable = true)
-    private void injectUpdate(ButtonWidget button, CallbackInfo ci) {
-        MinecraftClient.getInstance().setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(((KeybindsScreen) (Object) this), client -> {
-            for (KeyBinding keyBinding : client.options.allKeys) {
-                keyBinding.setBoundKey(keyBinding.getDefaultKey());
+    private void injectUpdate(Button button, CallbackInfo ci) {
+        Minecraft.getInstance().setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(((KeyBindsScreen) (Object) this), client -> {
+            for (KeyMapping keyBinding : client.options.keyMappings) {
+                keyBinding.setKey(keyBinding.getDefaultKey());
             }
 
             for (int i = 0; i < F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings().length; i++) {
@@ -39,8 +39,8 @@ public abstract class ResetAllKeybindsMixin {
                 keybinding.setBoundKey(keybinding.getDefaultKey());
             }
 
-            this.controlsList.update();
-        }, true), Text.translatable("text.not-enough-keybinds.resetAllKeys")));
+            this.keyBindsList.resetMappingAndUpdateButtons();
+        }, true), Component.translatable("text.not-enough-keybinds.resetAllKeys")));
         ci.cancel();
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ResetAllKeybindsMixin.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/mixin/ResetAllKeybindsMixin.java
@@ -22,7 +22,7 @@ public abstract class ResetAllKeybindsMixin {
     @Shadow private KeyBindsList keyBindsList;
 
     //confirmation dialog
-    @Inject(method = "method_60342", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "lambda$addFooter$0", at = @At("HEAD"), cancellable = true)
     private void injectUpdate(Button button, CallbackInfo ci) {
         Minecraft.getInstance().setScreen(Utils.getModConfirmScreen(new ParentScreenBlConsumer(((KeyBindsScreen) (Object) this), client -> {
             for (KeyMapping keyBinding : client.options.keyMappings) {

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/util/ElytraController.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/util/ElytraController.java
@@ -1,9 +1,9 @@
 package net.sn0wix_.notEnoughKeybinds.util;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.keybinds.InventoryKeys;
 
@@ -25,7 +25,7 @@ public class ElytraController {
     }
 
     public static boolean shouldSwapBack(ItemStack stack) {
-        return stack.isOf(swapBackItem);
+        return stack.is(swapBackItem);
     }
 
     public static int getSwapBackItemSlot() {
@@ -61,7 +61,7 @@ public class ElytraController {
 
         //player landed with auto-detect on
         try {
-            if (!MinecraftClient.getInstance().player.isGliding() && previousFallFlying && NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect) {
+            if (!Minecraft.getInstance().player.isFallFlying() && previousFallFlying && NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect) {
                 String swapFirstBefore = NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapFirst;
                 boolean swapSecondBefore = NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond;
 
@@ -69,13 +69,13 @@ public class ElytraController {
                 NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapFirst = "chestplate";
                 NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond = false;
 
-                InventoryKeys.EQUIP_ELYTRA.onWasPressed(MinecraftClient.getInstance());
+                InventoryKeys.EQUIP_ELYTRA.onWasPressed(Minecraft.getInstance());
 
                 //setting back the old parameters
                 NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapFirst = swapFirstBefore;
                 NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.swapSecond = swapSecondBefore;
             }
-            previousFallFlying = MinecraftClient.getInstance().player.isGliding();
+            previousFallFlying = Minecraft.getInstance().player.isFallFlying();
         }catch (NullPointerException ignored) {}
 
         //Enter flight mode logic
@@ -83,7 +83,7 @@ public class ElytraController {
             ticksToStartFlying--;
 
             try {
-                if (MinecraftClient.getInstance().player.isGliding()) {
+                if (Minecraft.getInstance().player.isFallFlying()) {
                     postFlight.run();
                     ticksToStartFlying = Integer.MIN_VALUE;
                 }
@@ -113,7 +113,7 @@ public class ElytraController {
         nextTick = runnable;
     }
 
-    public static int getTicksToStartFlying(MinecraftClient client) throws NullPointerException {
+    public static int getTicksToStartFlying(Minecraft client) throws NullPointerException {
         return NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.autoDetect ? 1 : client.player.isCreative() ? 8 : 3;
     }
 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/util/InventoryUtils.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/util/InventoryUtils.java
@@ -1,24 +1,30 @@
 package net.sn0wix_.notEnoughKeybinds.util;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.ingame.InventoryScreen;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.EnchantmentEffectComponentTypes;
-import net.minecraft.component.type.FireworksComponent;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.enchantment.Enchantments;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.inventory.Inventory;
-import net.minecraft.item.*;
-import net.minecraft.item.equipment.ArmorMaterials;
-import net.minecraft.registry.*;
-import net.minecraft.registry.tag.TagKey;
-import net.minecraft.screen.ScreenHandler;
-import net.minecraft.screen.slot.SlotActionType;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.*;
+import net.minecraft.core.registries.*;
+import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.Container;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerInput;
+import net.minecraft.world.item.FireworkRocketItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.Fireworks;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.equipment.ArmorMaterials;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 
 import java.util.Arrays;
@@ -27,16 +33,16 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class InventoryUtils {
-    public static int getFireworkSlot(PlayerInventory inventory, boolean longestDuration, boolean canExplode) {
+    public static int getFireworkSlot(Inventory inventory, boolean longestDuration, boolean canExplode) {
         int bestSlot = -1;
         int bestFlight = longestDuration ? -1 : Integer.MAX_VALUE;
 
 
-        for (int slot = 0; slot < inventory.size(); slot++) {
-            ItemStack stack = inventory.getStack(slot);
+        for (int slot = 0; slot < inventory.getContainerSize(); slot++) {
+            ItemStack stack = inventory.getItem(slot);
 
             if (stack.getItem() instanceof FireworkRocketItem) {
-                FireworksComponent component = stack.getComponents().get(DataComponentTypes.FIREWORKS);
+                Fireworks component = stack.getComponents().get(DataComponents.FIREWORKS);
                 if (!canExplode && !component.explosions().isEmpty()) continue;
 
 
@@ -51,16 +57,16 @@ public class InventoryUtils {
         return bestSlot;
     }
 
-    public static void switchInvHandSlot(MinecraftClient client, Hand hand, int clickedSlot) {
-        switchInvHotbarSlot(client, hand.equals(Hand.OFF_HAND) ? 40 : client.player.getInventory().getSelectedSlot(), clickedSlot);
+    public static void switchInvHandSlot(Minecraft client, InteractionHand hand, int clickedSlot) {
+        switchInvHotbarSlot(client, hand.equals(InteractionHand.OFF_HAND) ? 40 : client.player.getInventory().getSelectedSlot(), clickedSlot);
     }
 
-    public static void switchInvHotbarSlot(MinecraftClient client, int hotbarSlot, int clickedSlot) {
+    public static void switchInvHotbarSlot(Minecraft client, int hotbarSlot, int clickedSlot) {
         if (hotbarSlot > -1 && clickedSlot > -1) {
             assert client.player != null;
-            ScreenHandler handler = new InventoryScreen(client.player).getScreenHandler();
-            assert client.interactionManager != null;
-            client.interactionManager.clickSlot(handler.syncId, convertSlotIds(clickedSlot), hotbarSlot, SlotActionType.SWAP, client.player);
+            AbstractContainerMenu handler = new InventoryScreen(client.player).getMenu();
+            assert client.gameMode != null;
+            client.gameMode.handleContainerInput(handler.containerId, convertSlotIds(clickedSlot), hotbarSlot, ContainerInput.SWAP, client.player);
         }
 
         /*Maybe more legit?
@@ -69,33 +75,33 @@ public class InventoryUtils {
         client.setScreen(null);*/
     }
 
-    public static void equipChestplate(MinecraftClient client, int slot) {
+    public static void equipChestplate(Minecraft client, int slot) {
         //6 for chestplate and 0 for left mouse button click
         switchInvSlot(client, convertSlotIds(slot), 6, 0);
     }
 
-    public static void switchInvSlot(MinecraftClient client, int slot1, int slot2, int button) {
+    public static void switchInvSlot(Minecraft client, int slot1, int slot2, int button) {
         assert client.player != null;
-        ScreenHandler handler = new InventoryScreen(client.player).getScreenHandler();
+        AbstractContainerMenu handler = new InventoryScreen(client.player).getMenu();
 
-        assert client.interactionManager != null;
-        client.interactionManager.clickSlot(handler.syncId, slot1, button, SlotActionType.PICKUP, client.player);
-        client.interactionManager.clickSlot(handler.syncId, slot2, button, SlotActionType.PICKUP, client.player);
-        client.interactionManager.clickSlot(handler.syncId, slot1, button, SlotActionType.PICKUP, client.player);
+        assert client.gameMode != null;
+        client.gameMode.handleContainerInput(handler.containerId, slot1, button, ContainerInput.PICKUP, client.player);
+        client.gameMode.handleContainerInput(handler.containerId, slot2, button, ContainerInput.PICKUP, client.player);
+        client.gameMode.handleContainerInput(handler.containerId, slot1, button, ContainerInput.PICKUP, client.player);
     }
 
-    public static int getBestBreakableItemSlot(Inventory inventory, Item item, int mendingScore) {
+    public static int getBestBreakableItemSlot(Container inventory, Item item, int mendingScore) {
         HashMap<Integer, Integer> map = new HashMap<>();
 
-        for (int i = 0; i < inventory.size(); i++) {
-            ItemStack stack = inventory.getStack(i);
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            ItemStack stack = inventory.getItem(i);
 
-            if (stack.isOf(item)) {
-                Registry<Enchantment> registryManager = MinecraftClient.getInstance().world.getRegistryManager().getOrThrow(RegistryKeys.ENCHANTMENT);
+            if (stack.is(item)) {
+                Registry<Enchantment> registryManager = Minecraft.getInstance().level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
 
-                int unbreakingLevel = EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.UNBREAKING), stack);
-                int calculatedMendingScore = EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.MENDING), stack) > 0 ? mendingScore : 0;
-                int damageScore = (stack.getMaxDamage() - stack.getDamage()) * (unbreakingLevel + 1);
+                int unbreakingLevel = EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.UNBREAKING), stack);
+                int calculatedMendingScore = EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.MENDING), stack) > 0 ? mendingScore : 0;
+                int damageScore = (stack.getMaxDamage() - stack.getDamageValue()) * (unbreakingLevel + 1);
 
                 map.put(damageScore + calculatedMendingScore, i);
             }
@@ -110,16 +116,16 @@ public class InventoryUtils {
         return -1;
     }
 
-    public static void quickUseItem(MinecraftClient client, int slot) {
-        if (!PlayerInventory.isValidHotbarIndex(slot)) {
-            InventoryUtils.switchInvHandSlot(client, Hand.MAIN_HAND, slot);
-            InventoryUtils.interactItem(Hand.MAIN_HAND, client);
-            InventoryUtils.switchInvHandSlot(client, Hand.MAIN_HAND, slot);
+    public static void quickUseItem(Minecraft client, int slot) {
+        if (!Inventory.isHotbarSlot(slot)) {
+            InventoryUtils.switchInvHandSlot(client, InteractionHand.MAIN_HAND, slot);
+            InventoryUtils.interactItem(InteractionHand.MAIN_HAND, client);
+            InventoryUtils.switchInvHandSlot(client, InteractionHand.MAIN_HAND, slot);
 
         } else {
             int slotBefore = client.player.getInventory().getSelectedSlot();
             client.player.getInventory().setSelectedSlot(slot);
-            InventoryUtils.interactItem(Hand.MAIN_HAND, client);
+            InventoryUtils.interactItem(InteractionHand.MAIN_HAND, client);
             client.player.getInventory().setSelectedSlot(slotBefore);
         }
     }
@@ -128,23 +134,23 @@ public class InventoryUtils {
     /**
      * {//@link MinecraftClient#doItemUse()}
      */
-    public static void interactItem(Hand hand, MinecraftClient client) throws NullPointerException {
-        if (client.interactionManager.interactItem(client.player, hand) instanceof ActionResult.Success swingSource) {
-            if (swingSource.swingSource() == ActionResult.SwingSource.CLIENT) {
-                client.player.swingHand(hand);
+    public static void interactItem(InteractionHand hand, Minecraft client) throws NullPointerException {
+        if (client.gameMode.useItem(client.player, hand) instanceof InteractionResult.Success swingSource) {
+            if (swingSource.swingSource() == InteractionResult.SwingSource.CLIENT) {
+                client.player.swing(hand);
             }
         }
     }
 
-    public static int getSlotWithChestplate(MinecraftClient client) {
+    public static int getSlotWithChestplate(Minecraft client) {
         int slot = -1;
 
         if (NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestChestplate) {
             slot = getBestChestplateSlot(client.player.getInventory(), NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfVanishing, NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.acceptCurseOfBinding);
         } else {
-            for (int i = 0; i < client.player.getInventory().size(); i++) {
+            for (int i = 0; i < client.player.getInventory().getContainerSize(); i++) {
                 try {
-                    if (isChestplate(client.player.getInventory().getStack(i))) {
+                    if (isChestplate(client.player.getInventory().getItem(i))) {
                         slot = i;
                         break;
                     }
@@ -156,35 +162,35 @@ public class InventoryUtils {
         return slot;
     }
 
-    public static int getSlotWithElytra(MinecraftClient client) {
+    public static int getSlotWithElytra(Minecraft client) {
         return NotEnoughKeybinds.EQUIP_ELYTRA_CONFIG.chooseBestElytra ?
                 InventoryUtils.getBestBreakableItemSlot(client.player.getInventory(), Items.ELYTRA, 216)
                 : InventoryUtils.getSlotWithItem(Items.ELYTRA, client.player.getInventory());
 
     }
 
-    public static int getShieldSwapSlot(MinecraftClient client) {
+    public static int getShieldSwapSlot(Minecraft client) {
         return NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.chooseBestShield ?
                 InventoryUtils.getBestBreakableItemSlot(client.player.getInventory(), Items.SHIELD, NotEnoughKeybinds.TOTEM_SHIELD_CONFIG.swapMendingPoints)
                 : InventoryUtils.getSlotWithItem(Items.SHIELD, client.player.getInventory());
     }
 
-    public static int getTotemSwapSlot(MinecraftClient client, int lastShieldSlot) {
+    public static int getTotemSwapSlot(Minecraft client, int lastShieldSlot) {
         return lastShieldSlot > -1 ? lastShieldSlot : InventoryUtils.getSlotWithItem(Items.TOTEM_OF_UNDYING, client.player.getInventory());
     }
 
     //snagged from https://github.com/YumeGod/TheresaModules/blob/6f8fd374924ba8c7c4c2dd45153231b204e5eb73/player/AutoArmor.java
-    public static int getBestChestplateSlot(Inventory inventory, boolean acceptVanishing, boolean acceptBinding) {
+    public static int getBestChestplateSlot(Container inventory, boolean acceptVanishing, boolean acceptBinding) {
         int bestArmorSlot = -1;
         float bestArmorStrength = -1;
         int bestArmorDamage = Integer.MAX_VALUE;
 
-        for (int i = 0; i < inventory.size(); i++) {
-            if (!inventory.getStack(i).isEmpty()) {
-                final ItemStack stack = inventory.getStack(i);
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            if (!inventory.getItem(i).isEmpty()) {
+                final ItemStack stack = inventory.getItem(i);
 
-                if ((EnchantmentHelper.hasAnyEnchantmentsWith(stack, EnchantmentEffectComponentTypes.PREVENT_ARMOR_CHANGE) && !acceptBinding) ||
-                        (EnchantmentHelper.hasAnyEnchantmentsWith(stack, EnchantmentEffectComponentTypes.PREVENT_EQUIPMENT_DROP) && !acceptVanishing))
+                if ((EnchantmentHelper.has(stack, EnchantmentEffectComponents.PREVENT_ARMOR_CHANGE) && !acceptBinding) ||
+                        (EnchantmentHelper.has(stack, EnchantmentEffectComponents.PREVENT_EQUIPMENT_DROP) && !acceptVanishing))
                     continue;
 
 
@@ -195,10 +201,10 @@ public class InventoryUtils {
                         if (armorStrength > bestArmorStrength) {
                             bestArmorStrength = armorStrength;
                             bestArmorSlot = i;
-                            bestArmorDamage = stack.getDamage();
+                            bestArmorDamage = stack.getDamageValue();
 
-                        } else if (armorStrength == bestArmorStrength && stack.getDamage() < bestArmorDamage) {
-                            bestArmorDamage = stack.getDamage();
+                        } else if (armorStrength == bestArmorStrength && stack.getDamageValue() < bestArmorDamage) {
+                            bestArmorDamage = stack.getDamageValue();
                             bestArmorSlot = i;
                         }
                     }
@@ -213,15 +219,15 @@ public class InventoryUtils {
 
     public static float getFinalArmorStrength(ItemStack itemStack) {
         float rating = getArmorRating(itemStack);
-        Registry<Enchantment> registryManager = MinecraftClient.getInstance().world.getRegistryManager().getOrThrow(RegistryKeys.ENCHANTMENT);
+        Registry<Enchantment> registryManager = Minecraft.getInstance().level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
 
-        rating += EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.PROTECTION), itemStack) * 1.25F;
-        rating += EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.FIRE_ASPECT), itemStack) * 1.20F;
-        rating += EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.BLAST_PROTECTION), itemStack) * 1.20F;
-        rating += EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.PROTECTION), itemStack) * 1.20F;
-        rating += EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.FEATHER_FALLING), itemStack) * 0.33F;
-        rating += EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.THORNS), itemStack) * 0.10F;
-        rating += EnchantmentHelper.getLevel(registryManager.getOrThrow(Enchantments.UNBREAKING), itemStack) * 0.05F;
+        rating += EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.PROTECTION), itemStack) * 1.25F;
+        rating += EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.FIRE_ASPECT), itemStack) * 1.20F;
+        rating += EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.BLAST_PROTECTION), itemStack) * 1.20F;
+        rating += EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.PROTECTION), itemStack) * 1.20F;
+        rating += EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.FEATHER_FALLING), itemStack) * 0.33F;
+        rating += EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.THORNS), itemStack) * 0.10F;
+        rating += EnchantmentHelper.getItemEnchantmentLevel(registryManager.getOrThrow(Enchantments.UNBREAKING), itemStack) * 0.05F;
         return rating;
     }
 
@@ -229,20 +235,20 @@ public class InventoryUtils {
         float rating = 1;
 
         try {
-            Optional<TagKey<Item>> tagKey = itemStack.get(DataComponentTypes.REPAIRABLE).items().getTagKey();
+            Optional<TagKey<Item>> tagKey = itemStack.get(DataComponents.REPAIRABLE).items().unwrapKey();
 
             if (tagKey.isPresent()) {
-                 if (tagKey.get().id().equals(ArmorMaterials.COPPER.repairIngredient().id())) {
+                 if (tagKey.get().location().equals(ArmorMaterials.COPPER.repairIngredient().location())) {
                     rating = 2;
-                } else if (tagKey.get().id().equals(ArmorMaterials.GOLD.repairIngredient().id())) {
+                } else if (tagKey.get().location().equals(ArmorMaterials.GOLD.repairIngredient().location())) {
                     rating = 2;
-                } else if (tagKey.get().id().equals(ArmorMaterials.CHAIN.repairIngredient().id())) {
+                } else if (tagKey.get().location().equals(ArmorMaterials.CHAINMAIL.repairIngredient().location())) {
                     rating = 3;
-                } else if (tagKey.get().id().equals(ArmorMaterials.IRON.repairIngredient().id())) {
+                } else if (tagKey.get().location().equals(ArmorMaterials.IRON.repairIngredient().location())) {
                     rating = 4;
-                } else if (tagKey.get().id().equals(ArmorMaterials.DIAMOND.repairIngredient().id())) {
+                } else if (tagKey.get().location().equals(ArmorMaterials.DIAMOND.repairIngredient().location())) {
                     rating = 5;
-                } else if (tagKey.get().id().equals(ArmorMaterials.NETHERITE.repairIngredient().id())) {
+                } else if (tagKey.get().location().equals(ArmorMaterials.NETHERITE.repairIngredient().location())) {
                     rating = 6;
                 }
             }
@@ -255,7 +261,7 @@ public class InventoryUtils {
     public static int convertSlotIds(int slot) {
         //For some stupid reason, the hotbar slots are different
         //https://wiki.vg/File:Inventory-slots.png
-        if (PlayerInventory.isValidHotbarIndex(slot)) {
+        if (Inventory.isHotbarSlot(slot)) {
             slot += 36;
         } else if (slot == 40) {
             slot = 45;
@@ -264,9 +270,9 @@ public class InventoryUtils {
         return slot;
     }
 
-    public static int getSlotWithItem(Item item, PlayerInventory inventory) {
-        for (int i = 0; i < inventory.getMainStacks().size(); i++) {
-            if (!inventory.getMainStacks().get(i).isEmpty() && inventory.getMainStacks().get(i).isOf(item)) {
+    public static int getSlotWithItem(Item item, Inventory inventory) {
+        for (int i = 0; i < inventory.getNonEquipmentItems().size(); i++) {
+            if (!inventory.getNonEquipmentItems().get(i).isEmpty() && inventory.getNonEquipmentItems().get(i).is(item)) {
                 return i;
             }
         }
@@ -278,8 +284,8 @@ public class InventoryUtils {
         AtomicBoolean bl = new AtomicBoolean(false);
 
         try {
-            itemStack.get(DataComponentTypes.ATTRIBUTE_MODIFIERS).modifiers().forEach(modifier -> {
-                if (modifier.modifier().id().equals(Identifier.ofVanilla("armor.chestplate"))) {
+            itemStack.get(DataComponents.ATTRIBUTE_MODIFIERS).modifiers().forEach(modifier -> {
+                if (modifier.modifier().id().equals(Identifier.withDefaultNamespace("armor.chestplate"))) {
                     bl.set(true);
                 }
             });

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/util/TextUtils.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/util/TextUtils.java
@@ -1,37 +1,37 @@
 package net.sn0wix_.notEnoughKeybinds.util;
 
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.tooltip.Tooltip;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 
 public class TextUtils {
-    public static Text getCombinedTranslation(Text translation1, Text translation2) {
-        return Text.of(translation1.getString() + translation2.getString());
+    public static Component getCombinedTranslation(Component translation1, Component translation2) {
+        return Component.nullToEmpty(translation1.getString() + translation2.getString());
     }
 
     public static String getTranslationKey(String path) {
         return getTranslationKey(path, false);
     }
 
-    public static Text getText(String path) {
-        return Text.translatable(getTranslationKey(path));
+    public static Component getText(String path) {
+        return Component.translatable(getTranslationKey(path));
     }
 
-    public static Text getText(String path, Object... args) {
-        return Text.translatable(getTranslationKey(path), args);
+    public static Component getText(String path, Object... args) {
+        return Component.translatable(getTranslationKey(path), args);
     }
 
-    public static Text getText(String path, boolean tooltip) {
-        return Text.translatable(getTranslationKey(path, tooltip));
+    public static Component getText(String path, boolean tooltip) {
+        return Component.translatable(getTranslationKey(path, tooltip));
     }
 
     public static Tooltip getTooltip(String path) {
-        return Tooltip.of(getText(path, true));
+        return Tooltip.create(getText(path, true));
     }
 
     public static Tooltip getTooltip(String path, Object... args) {
-        return Tooltip.of(Text.translatable(getTranslationKey(path, true), args));
+        return Tooltip.create(Component.translatable(getTranslationKey(path, true), args));
     }
 
     public static String getTranslationKey(String path, boolean tooltip) {
@@ -42,13 +42,13 @@ public class TextUtils {
         return "settings." + NotEnoughKeybinds.MOD_ID + "." + path;
     }
 
-    public static String trimText(String text, TextRenderer textRenderer, int maxWidth) {
+    public static String trimText(String text, Font textRenderer, int maxWidth) {
         String textToRender = text;
         try {
-            if (maxWidth < textRenderer.getWidth(text)) {
+            if (maxWidth < textRenderer.width(text)) {
                 StringBuilder builder = new StringBuilder();
                 int i = 0;
-                while (textRenderer.getWidth(builder + "...") < maxWidth) {
+                while (textRenderer.width(builder + "...") < maxWidth) {
                     builder.append(textToRender.charAt(i));
                     i++;
                 }

--- a/src/main/java/net/sn0wix_/notEnoughKeybinds/util/Utils.java
+++ b/src/main/java/net/sn0wix_/notEnoughKeybinds/util/Utils.java
@@ -1,12 +1,11 @@
 package net.sn0wix_.notEnoughKeybinds.util;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.input.KeyInput;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.toast.SystemToast;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.toasts.SystemToast;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.network.chat.Component;
 import net.sn0wix_.notEnoughKeybinds.NotEnoughKeybinds;
 import net.sn0wix_.notEnoughKeybinds.gui.AdvancedConfirmScreen;
 import net.sn0wix_.notEnoughKeybinds.gui.ParentScreenBlConsumer;
@@ -23,17 +22,17 @@ import java.util.stream.Stream;
 
 public class Utils {
 
-    public static Screen getModConfirmScreen(ParentScreenBlConsumer consumer, Text text) {
-        return new AdvancedConfirmScreen(consumer, Text.empty(), text,
-                Text.translatable("text.not-enough-keybinds.confirm." + new Random().nextInt(4)),
-                Text.translatable("text.not-enough-keybinds.cancel." + new Random().nextInt(4)));
+    public static Screen getModConfirmScreen(ParentScreenBlConsumer consumer, Component text) {
+        return new AdvancedConfirmScreen(consumer, Component.empty(), text,
+                Component.translatable("text.not-enough-keybinds.confirm." + new Random().nextInt(4)),
+                Component.translatable("text.not-enough-keybinds.cancel." + new Random().nextInt(4)));
     }
 
 
-    public static KeyBinding[] filterModKeybindings(KeyBinding[] keyBindings) {
-        ArrayList<KeyBinding> newBindings = new ArrayList<>();
+    public static KeyMapping[] filterModKeybindings(KeyMapping[] keyBindings) {
+        ArrayList<KeyMapping> newBindings = new ArrayList<>();
 
-        for (KeyBinding keyBinding : keyBindings) {
+        for (KeyMapping keyBinding : keyBindings) {
             if (keyBinding instanceof NotEKKeyBinding) {
                 continue;
             }
@@ -41,7 +40,7 @@ public class Utils {
             newBindings.add(keyBinding);
         }
 
-        KeyBinding[] finalBindings = new KeyBinding[newBindings.size()];
+        KeyMapping[] finalBindings = new KeyMapping[newBindings.size()];
 
         for (int i = 0; i < newBindings.size(); i++) {
             finalBindings[i] = newBindings.get(i);
@@ -50,11 +49,11 @@ public class Utils {
         return finalBindings;
     }
 
-    public static List<Integer> checkF3Shortcuts(KeyInput input) {
+    public static List<Integer> checkF3Shortcuts(KeyEvent input) {
         ArrayList<Integer> codes = new ArrayList<>();
 
         F3ShortcutsKeys.getF3ShortcutKeys().forEach(f3ShortcutKeybinding -> {
-            if (f3ShortcutKeybinding.matchesKey(input)) {
+            if (f3ShortcutKeybinding.matches(input)) {
                 codes.add(f3ShortcutKeybinding.getCodeToEmulate());
             }
         });
@@ -63,19 +62,19 @@ public class Utils {
     }
 
 
-    public static Text correctF3DebugMessage(Text message) {
+    public static Component correctF3DebugMessage(Component message) {
         String translatedMessage = message.getString();
         String f3String = "F3 + ";
         for (int i = 0; i < F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings().length; i++) {
             String newKey = F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings()[i].getBoundKeyLocalizedText().getString().replace(f3String, "");
-            String oldKey = F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings()[i].getDefaultKey().getLocalizedText().getString();
+            String oldKey = F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings()[i].getDefaultKey().getDisplayName().getString();
 
             if (translatedMessage.contains(f3String + oldKey)) {
                 translatedMessage = translatedMessage.replace(f3String + oldKey, f3String + newKey);
             }
         }
 
-        return Text.of(translatedMessage);
+        return Component.nullToEmpty(translatedMessage);
     }
 
     public static Object[] addArgToEnd(Object[] args, Object addedArg) {
@@ -118,14 +117,14 @@ public class Utils {
     public static List<String> bindingsToList(boolean defaultBindings) {
         ArrayList<String> bindingsList = new ArrayList<>();
 
-        Stream.of(MinecraftClient.getInstance().options.allKeys, ChatKeys.CHAT_KEYS_MOD_CATEGORY.getKeyBindings(), F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings()).toList().forEach(bindings -> {
+        Stream.of(Minecraft.getInstance().options.keyMappings, ChatKeys.CHAT_KEYS_MOD_CATEGORY.getKeyBindings(), F3DebugKeys.F3_DEBUG_KEYS_CATEGORY.getKeyBindings()).toList().forEach(bindings -> {
             if (bindings instanceof INotEKKeybinding[] newBindings) {
                 for (INotEKKeybinding binding : newBindings) {
-                    bindingsList.add(binding.getId() + ":" + (defaultBindings ? binding.getDefaultKey().getTranslationKey() : binding.getBoundKeyTranslation()));
+                    bindingsList.add(binding.getId() + ":" + (defaultBindings ? binding.getDefaultKey().getName() : binding.getBoundKeyTranslation()));
                 }
-            } else if (bindings instanceof KeyBinding[] newBindings) {
-                for (KeyBinding binding : newBindings) {
-                    bindingsList.add(binding.getId() + ":" + (defaultBindings ? binding.getDefaultKey().getTranslationKey() : binding.getBoundKeyTranslationKey()));
+            } else if (bindings instanceof KeyMapping[] newBindings) {
+                for (KeyMapping binding : newBindings) {
+                    bindingsList.add(binding.getName() + ":" + (defaultBindings ? binding.getDefaultKey().getName() : binding.saveString()));
                 }
             }
         });
@@ -133,11 +132,11 @@ public class Utils {
         return bindingsList;
     }
 
-    public static void showToastNotification(Text description) {
-        MinecraftClient.getInstance().getToastManager().add(new SystemToast(new SystemToast.Type(2769), Text.literal(NotEnoughKeybinds.MOD_NAME), description));
+    public static void showToastNotification(Component description) {
+        Minecraft.getInstance().getToastManager().addToast(new SystemToast(new SystemToast.SystemToastId(2769), Component.literal(NotEnoughKeybinds.MOD_NAME), description));
     }
 
-    public static void showToastNotification(Text description, long displayDuration) {
-        MinecraftClient.getInstance().getToastManager().add(new SystemToast(new SystemToast.Type(displayDuration), Text.literal(NotEnoughKeybinds.MOD_NAME), description));
+    public static void showToastNotification(Component description, long displayDuration) {
+        Minecraft.getInstance().getToastManager().addToast(new SystemToast(new SystemToast.SystemToastId(displayDuration), Component.literal(NotEnoughKeybinds.MOD_NAME), description));
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,8 @@
 	],
 	"depends": {
 		"fabricloader": "*",
-		"minecraft": ">=1.21.9 <=1.21.10",
-		"java": ">=21",
+		"minecraft": ">=26.1 <=26.1.2",
+		"java": ">=25",
 		"fabric-api": "*",
 		"yet_another_config_lib_v3": "*"
 	},


### PR DESCRIPTION
## Summary
- Port the mod to Minecraft 26.1.2, Fabric Loader 0.19.3, Fabric API 0.152.1+26.1.2, and Java 25
- Migrate the codebase from Yarn-style names to Mojang mappings for the 26.x toolchain
- Update client GUI, key mapping, registry, item, identifier, and inventory input API usages
- Fix runtime Mixin targets for the 26.1.2 controls screen and relax the removed debug help message injection

## Verification
- ./gradlew build passes locally with Java 25
- Confirmed the generated jar starts in a Modrinth Minecraft 26.1.2 Fabric profile on Windows

## Notes
- KeyboardMixin#fixHelpMessage now uses require = 0 because the old debug help chat path no longer exists in 26.1.2. This preserves startup while leaving the obsolete help-message replacement inactive when the target is absent.